### PR TITLE
subtree update: abb810efff -> 9ae2f5401a

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 3cf2475ea059184820525bb949c11c3da0e64af8
+last_revision = a13db91f19ef113bfb5f23fc15db27af558ef9a8
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = c7f4c739a3762b9a39696898876f242b17df6f59
+last_revision = 32921fc9bd59a93c7bda20594cca6c33a64927f7
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = 96f122efe48f239f7b5df4025acd5c98a61828b3
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 492205ea83d4a4ae8baf9fabdf73440ba66123ab
+last_revision = 94dfcaff64ee971d9e5a3edebe8f13ca20ea3555
 


### PR DESCRIPTION
poky 492205ea83 -> 94dfcaff64:
    applied ae6153e10b2... test-manual: Add extra detail to YP Compatible section
    applied eb047a25bbc... migration-3.4: Add extra notes to override syntax changes
    applied 23e640b8093... manuals: mention license information in footer
    applied 4c7e3b64bc9... manuals: further documentation for cve-check
    applied 77ce05bd36c... releases: update to include 3.1.10
    applied ad454e02663... glibc: Upgrade to 2.34 release
    applied 1f6bc6580c1... glibc: Remove obsolete --enable-stackguard-randomization
    applied ea74dcc0595... glibc: Drop DUMMY_LOCALE_T define patch
    applied 7e5145f2c53... glibc: Add missing symlinks for libpthread and librt dev files
    applied 36ed0c29cbc... valgrind: skip broken ptests for glibc 2.34
    applied 488aa36a61a... bitbake.conf: add DEBUG_PREFIX_MAP to TARGET_LDFLAGS
    applied d1a599bc403... ruby: Fix DEBUG_PREFIX_MAP in LDFLAGS issue
    applied 666548c44e2... gettext: Fix reproducibility issue with LDFLAGS
    applied fa91de383e0... ruby: Fix reproducibility issue with LDFLAGS
    applied 2e4f162e615... curl: Fix reproducibility issue with LDFLAGS
    applied 9262d89763d... ell: upgrade 0.41 -> 0.42
    applied 2f743b47393... libtool: Fix lto option passing for reproducible builds
    applied 62372aedfe5... convert-overrides.py: also convert comments without a leading whitespace
    applied 2e4d3aa2a35... meta: use new override syntax in comments
    applied a99473976d9... cve-check: remove deprecated CVE_CHECK_CVE_WHITELIST
    applied 2377193d7a1... lib/oe: add generic functions for overlayfs
    applied d6e1f08ee38... overlayfs.bbclass: generate overlayfs mount units
    applied 550511e446d... rootfs-postcommands: add QA check for overlayfs
    applied 9b5fbdea3df... systemd-machine-units: add bbappend for meta-selftest
    applied 44bbb74b766... overlayfs: meta-selftest recipe
    applied 0413829f619... oeqa/selftest: overlayfs unit tests
    applied 68462353450... MAINTAINERS: add overlayfs maintainer
    applied 88fe4195439... e2fsprogs: ensure small images have 256-byte inodes
    applied c1b7a9cd64f... wic: don't forcibly pass -T default
    applied 917134a8050... parted: drop unneeded ld-is-gold patch
    applied 635e21fdd56... parted: update patch status
    applied 43af729d310... buildtools-tarball: add testsdk task
    applied 262587d754b... oeqa/sdk: add some buildtools tests
    applied ea14728154f... libconvert-asn1-perl: 0.27 -> 0.31
    applied 33ba016f4c5... sstate.bbclass: fix error handling when sstate mirrors is ro
    applied 8ae0ee62cac... multilib.bbclass: fix new override syntax for virtclass-multilib
    applied 650b720f191... baremetal-helloworld: Enable RISC-V 32 port
    applied 52cd4ae51aa... linux-firmware: add more Qualcomm firmware packages
    skipped 50cbb9f0a43... pixman: re-disable iwmmxt
    applied 36d00389826... libjpeg-turbo: Handle powerpc64le without Altivec
    applied bba3e17098d... kmod: use nonarch_base_libdir for depmod.d and modprobe.d
    applied fb12b7a1cdc... pixman: Handle PowerPC without Altivec
    applied 0975ff9b69b... python3-scons{-native}: upgrade 4.1.0 -> 4.2.0
    applied 62098f90411... bitbake: utils: add environment updating context manager
    applied 34838413527... bitbake: fetch2: expose environment variable names that need to be exported
    applied ad507bd5c4e... bitbake: fetch2/wget: ensure all variables are set when calling urllib
    applied 1e2e9a84d6d... bitbake: fetch2/wget: fetch securely by default
    applied c5ae7decf38... u-boot: Package extlinux.conf separately
    applied 4e413911df6... dbus: add PACKAGECONFIG for audit and selinux
    applied b3246ebd87a... util-linux: fix CVE-2021-37600
    applied a4289601839... pypi: Allow override of PyPI archive name
    applied 50d8801d72f... kernel-fitimage: images should not be signed with the same keys as the configurations
    applied da6ba4d0b88... oeqa/selftest/fitimage: update tests to use two keys
    applied 7c88e08e62d... sdk: fix relocate symlink failed
    applied dac9318c5a7... tune-cortexm*: add support for all Arm Cortex-M processors
    applied a38e358e163... glib-2.0: add PACKAGECONFIG for selinux
    applied 46e975c5811... shadow: add PACKAGECONFIG for audit and selinux
    applied 47c32a99aea... systemd: add zstd PACKAGECONFIG
    applied b2bda4828bb... systemd: set zstd as default PACKAGECONFIG
    applied 9fe8f880260... util-linux: add back manpages related settings
    applied 3ae80177fb7... insane.bbclass: fix new override syntax migration
    applied fa6c07bc1a5... classes/cve-check: Move get_patches_cves to library
    applied 8a09663e7c6... lib/packagedata: Fix for new overrides
    applied 26f1ecb72d5... oeqa/runtime/cases: make date.DateTest.test_date more reliable
    applied 0edac1f2336... perl: do_create_rdepends_inc override syntax
    applied 49ae4a23d8a... terminal.bbclass: force bash for devshell
    applied ddd4b8c9a1b... package.bbclass: FILER* override syntax
    applied 8ff845c9ba1... dbus_%.bbappend: stop using selinux_set_mapping
    applied 4f2356a0818... bsp-guide: overrides syntax updates
    applied ded502d2a75... dev-manual: overrides syntax updates
    applied 80859f21b5c... kernel-dev manual: overrides syntax updates
    applied 956056e647e... ref-manual: overrides syntax updates
    applied 134da15e223... sdk-manual: overrides syntax updates
    applied ed6482821c1... test-manual: overrides syntax updates
    applied 3d93ddf9e88... docs: fix new override syntax migration
    applied 52db0c75754... docs: overview-manual: concepts: remove long-gone BBHASHDEPS variable
    applied b5f203516b3... sdk-manual: reference obsolete reference to ADT
    applied 350197e46a4... Manuals: replace "file name" by "filename"
    applied 0cf790a0fe4... dev-manual: fix grammar in post-install script explanations
    applied cb8c550da40... docs: fix typo in releases
    applied 98ca1114ef6... common-tasks: Add a summary to the end of the bbappend example
    applied 2eb5550db45... manuals: Rename the "Using .bbappend Files in Your Layer" section
    applied 0b8f844c8c0... kickstart: document which options accept units
    applied 94dfcaff64e... tar: ignore node-tar CVEs
meta-raspberrypi c7f4c739a3 -> 32921fc9bd:
    applied fc5d68f1359... rpi-config: Allow setting hdmi_cvt
    applied 32921fc9bd5... linux-firmware-rpidistro: fix wifi driver loading on cm4
meta-openembedded 3cf2475ea0 -> a13db91f19:
    applied c40e01b0fce... curlpp: fix QA Issue after LDFLAGS change
    applied a4791bf2f37... ldns: fix QA Issue after LDFLAGS change
    applied 5013bd7b304... vorbis-tools: update to 1.4.2 (latest in 1.4.x series)
    applied a8c964d14c3... image_types_sparse: fix sparse image generation
    applied c80b3757ffc... libdbi-perl: fix CVE-2014-10402
    applied 242ba8e2fc4... Convert to new override syntax using latest convert-overrides.py script
    applied 7fd9678e645... ndpi: fix CVE-2021-36082
    applied 48596d4db3b... tcsh: fix compile error after LDFLAGS change
    applied 02aeda00ab3... cifs-utils: typo fix fakse --> false
    applied 369fd1efe91... jemalloc: fix the race during do_install
    applied 7a512dfc242... audit: upgrade 3.0.3 -> 3.0.4
    applied 61638bdba38... jemalloc: add ptest support
    applied 4f0d10e870e... mycroft: Install more tools needed by scripts
    applied 223243d649b... bigbuckbunny-1080p: fix sample video URL
    applied 344bb081f5c... opus-tools: update to 0.2, move to meta-multimedia and fix license
    applied 71c5cc44c72... jemalloc: improve the ptest output
    applied 643d09d6236... augeas: rename PACKAGECONFIG[libselinux] to PACKAGECONFIG[selinux]
    applied 9a93c7666fc... network-manager-applet: add selinux to PACKAGECONFIG if enable selinux distro feature
    applied 4940e9fb6ac... networkmanager: add PACKAGECONFIG for audit and selinux
    applied ed556a580a9... augeas: add selinux to PACKAGECONFIG if enable selinux distro feature
    applied ae5b7d4c03e... iwd: upgrade 1.15 -> 1.16
    applied c5f2e9ce18a... ttf-ipa: Added a new font.
    applied 005ca8814ee... packagegroup-meta-oe: Add ttf-ipa
    applied dbde7fc3ccc... python3-grpcio: make sure that GRPC_CFLAGS is expanded to empty
    applied 67b1b1211f1... python3-engineio: upgrade 4.2.0 -> 4.2.1
    applied 44492ab1b86... python3-humanize: upgrade 3.10.0 -> 3.11.0
    applied b655693eb00... python3-ipython: upgrade 7.25.0 -> 7.26.0
    applied 34d7b7c7065... python3-isort: upgrade 5.9.2 -> 5.9.3
    applied fec4fa46df1... python3-astroid: Upgrade 2.6.5 -> 2.6.6
    applied 1d733f475fd... python3-gast: Upgrade 0.5.1 -> 0.5.2
    applied d0827957446... python3-greenlet: Upgrade 1.1.0 -> 1.1.1
    applied 9350b539e0e... python3-bitarray: Upgrade 2.2.3 -> 2.2.5
    applied 29221c12747... python3-send2trash: Upgrade 1.7.1 -> 1.8.0
    applied 8ccc92e7dbc... python3-defusedxml: extend recipe to add native support
    applied da37fce2ab1... python3-zeroconf: Upgrade 0.33.2 -> 0.34.3
    applied 0aa3b3e0c2c... python3-aiohue: Upgrade 2.5.1 -> 2.6.1
    applied 8c6f98157ee... python3-configargparse: Upgrade 1.5.1 -> 1.5.2
    applied c40c069a73c... python3-pycurl: Upgrade 7.43.0.6 -> 7.44.0
    applied 82c9ddd853c... python3-distro: Upgrade 1.5.0 -> 1.6.0
    applied 5d6fc2c1a18... python3-m2crypto: fix for new overrides syntax
    applied b21cad88671... python3-google-api-core: Upgrade 1.30.0 -> 1.31.1
    applied 89312caa4b3... python3-google-auth: Upgrade 1.32.0 -> 1.34.0
    applied 66d636c27ca... python3-google-api-python-client: Upgrade 2.12.0 -> 2.15.0
    applied 081eda0d368... python3-huey: Upgrade 2.3.2 -> 2.4.0
    applied a13db91f19e... python3-apply-defaults: Upgrade 0.1.4 -> 0.1.6

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
