### PR TITLE
subtree update: 17e10e6463 -> 93c203f3a3

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = cff8331f9625b2a9f1ffefef4519763b410eb33c
+last_revision = 23dc4f060f3d96af02c1c69d7b004352d79d7bb5
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -14,7 +14,7 @@ last_revision = 9eb4879cf4a289607ec7493577adb0ba97367821
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = de6712a806e0b0df2e07640388d212e2f4681374
+last_revision = a85fbe980e5bc6acb50c0b2d520e65b98c7b3cd9
 
 [meta-xilinx]
 src_uri = git://git.yoctoproject.org/meta-xilinx
@@ -26,5 +26,5 @@ last_revision = 96f122efe48f239f7b5df4025acd5c98a61828b3
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 06dcace68b021b020f14327c35358d58ecc698fa
+last_revision = 80f2b56ad8c270269d9f7f65cc114d8f13f9dfbb
 


### PR DESCRIPTION
meta-security de6712a806 -> a85fbe980e:
    applied 1bf7f30ca98... chkrootkit: update to 0.55
    applied 6a19cc9f003... recipes-security/fscrypt: Add fscrypt .bb file
    applied 650e6d6d4bb... dmverity: Make use of DATA_BLOCK_SIZE variable in initrdscript.
    applied ea062563aaa... clamav: Set clamav:clamav ownership on /var/lib/clamav in do_install
    applied 36739546691... libtpm: update to 0.8.7
    applied a85fbe980e5... Upgrade parsec-service 0.8.1 and parsec-tool 0.4.0
poky 06dcace68b -> 80f2b56ad8:
    applied eafac9940ad... inetutils: fix CVE-2021-40491
    applied bcf0b252485... ffmpeg: fix CVE-2021-38171
    applied eb61ab40882... linux-yocto-dev: update to v5.15-rcX
    applied 7b394706605... lttng-modules/dev-upstream: update to 2.13-latest
    applied b5fba5026bd... lttng-modules: fix build against 5.15+
    applied 8bcec870b4c... linux-yocto/5.13: drop recipes
    applied 7f66855d117... bzip2: Update soname for libbz2 1.0.8
    applied 24a32132a58... libsamplerate0: Set correct soname for 0.1.9
    applied 1d2e3d006a7... oeqa/qemurunner: Use oe._exit(), not sys.exit()
    applied a6f6bcb9db2... pseudo: Add in ability to flush database with shutdown request
    applied d6a0c614327... autotools.bbclass: use ordinary append for file-checksums update
    applied 4e5321e4bbc... packagegroup-core-tools-profile: Exclude systemtap from riscv32 as well
    applied 2692037fec9... yocto-bsp/5.13: drop recipes
    applied eab1c2087fd... bitbake: bitbake-worker: Allow shutdown/database flush of pseudo server at task exit
    applied 72e03d8a91f... bitbake: siggen: Fix sorting in diff output
    applied 2446bdf59ae... bitbake: cooker/command: Add a dummy event for tinfoil testing
    applied 4252b898656... oeqa/selftest/gotoolchain: Fix temp file cleanup
    applied 694a1ae8f81... oeqa/buildproject: Ensure temp directories are cleaned up
    applied c4f0ccb5612... libc_package/buildstats: Fix python regex quoting warnings
    applied 37b4fa7a102... wic:direct.py: ignore invalid mountpoints during fstab update
    applied a3d96f122c9... oeqa/selftest/tinfoil: Update to use test command
    applied 0afeb9f7402... releases: update to include 3.1.11
    applied 165b089a7dd... kernel.bbclass: remove unnecessary dead code
    applied 4ba745f8286... hello-mod/hello.c: convert printk to pr_xxx
    applied da9409d26e5... glew: Stop polluting /tmp during builds
    applied 0e80ffc6c83... spdx-licenses.json: Use 3.14 tagged version
    applied 64ebd0d97c2... package_ipk: Use localdata store when signing packages
    applied 859e6a0d00f... spdx.py: Add SPDXAnnotation Object
    applied 6d98af48f43... create-spdx: Use SPDXAnnotation to track native recipes
    applied 17bd442f1a3... lib/oe/spdx.py: Add comments
    applied 3af6389ece4... rm_work.bbclass: Fix for files starting with -
    applied 35b8966e611... recipes-support/ptest-runner: Bump to v2.4.2
    applied 59a0f26b8a5... vim: fix CVE-2021-3778
    applied 327ea9d446d... scriptutils.py: Add check before deleting path
    applied 3ac9722e0fb... ovmf: add TPM PACKAGECONFIG and enable if tpm is in MACHINE_FEATURES
    applied c619d748ab7... libevent: mark util/monotonic_prc_fallback as retriable
    applied cf08db9f832... strace: upgrade 5.13 -> 5.14
    applied 3115aa157de... python3: Fix sysroot reproducibility
    applied aeb712ebb05... ruby: fix the reproducibility issue
    applied b6b6e81db12... ref-manual: extend explanation of PACKAGE_DEBUG_SPLIT_STYLE
    applied f25e408268e... ref-manual: fix missed override syntax change
    applied 65cfd937a2a... ref-manual: mention INHIBIT_PACKAGE_DEBUG_SPLIT variable
    applied b0eedf4dcaa... common-tasks: add note about license implications of bundled initramfs
    applied b82097b9c0b... ref-manual: add note about license implications of bundled initramfs
    applied 6c29f198d92... overview-manual: delete bad backslashes in SSTATE_MIRRORS example
    applied b6e74ba64eb... rpm: Ensure compression parallelism isn't coded into rpms
    applied a543230b342... package: Ensure pclist files are deterministic and don't use full paths
    applied 9f0b69e91c5... gnupg: Be deterministic about sendmail
    applied 86125379b2a... mesa: Ensure megadrivers runtime mappings are deterministic
    applied 3539c214dd6... util-linux: Fix reproducibility
    applied 0e7806771e8... libtool: Allow libtool-cross to reproduce
    applied 089b8d3e7e3... gobject-introspection: Don't write $HOME into scripts
    applied 6a276318af3... oeqa/selftest/bbtests: Add uuid to force build test
    applied 830059cdeb6... image: Exclude IMAGE_VERSION_SUFFIX from expansion in image tasks
    applied 1b3415acd28... sstatesig: Revert "Test cross/native hashserv method extension"
    applied 75b79d5c056... bitbake: data: Ensure functions are defined in a deterministic order
    applied b8c0f073f6a... wic/bootimg-efi: Add Unified Kernel Image option
    applied aedb8d58ea6... bitbake.conf: Set vardepvalue for PARALLEL_MAKEINST
    applied 0b4198eeac0... externalsrc: Fix a source date epoch race in reproducible builds
    applied 86c7d3e0310... sstatesig: Add processing for full build paths in sysroot files
    applied 58298e97176... python3: Drop broken pyc files
    applied 1c37bbab4ff... image-artifact-names: Use SOURCE_DATE_EPOCH when making reproducible builds for deploy
    applied a26db5c9447... abi_version/sstate: Bump HASH_VERSION and SSTATE_VERSION
    applied 80f2b56ad8c... reproducible_build: Work around caching issues
meta-openembedded cff8331f96 -> 23dc4f060f:
    applied dd0cd45d18e... python3-pychromecast: upgrade 9.2.0 -> 9.2.1
    applied 3c257b34170... python3-pyro4: upgrade 4.80 -> 4.81
    applied 81a7b2cdf31... python3-pyzmq: upgrade 22.2.1 -> 22.3.0
    applied e177fb82216... python3-robotframework: upgrade 4.1 -> 4.1.1
    applied 8906fbe1719... python3-sqlparse: upgrade 0.4.1 -> 0.4.2
    applied 7ed3c97bc9c... python3-tqdm: upgrade 4.62.2 -> 4.62.3
    applied b70bb9b43c2... netdata: Move the version to the file name and correct the SRC_URI
    applied def97d2331c... README: update to main repo
    applied d6cfc0183f6... unionfs-fuse: upgrade 2.1 -> 2.2
    applied 242a96b6c68... smcroute: upgrade 2.4.4 -> 2.5.3
    applied f3960b6c69b... snort: upgrade 2.9.18 -> 2.9.18.1
    applied 990dcd88a42... libjs-jquery-icheck: Add recipe
    applied 183338ef53a... libsass: upgrade 3.6.4 -> 3.6.5
    applied a4f9c009e09... sanlock: upgrade 3.8.3 -> 3.8.4
    applied 437513e8eec... sassc: upgrade 3.6.1 -> 3.6.2
    applied e06935c6c13... smarty: Add recipe
    applied d496950bdee... valijson: upgrade 0.5 -> 0.6
    applied 6501ca786af... smcroute: Add missing pkgconfig inherit
    applied 6cdaf5cc068... python3-cmd2: upgrade 2.1.2 -> 2.2.0
    applied 796b7f6f4c5... python3-huey: upgrade 2.4.0 -> 2.4.1
    applied a49f8f77329... python3-humanfriendly: upgrade 9.2 -> 10.0
    applied a33507c3722... python3-humanfriendly: Add nativesdk to BBCLASSEXTEND
    applied d0518c1ed98... layer.conf: add openembedded-layer as LAYERDEPENDS
    applied 0c38f98f120... packagegroup-meta-oe: Add new packages smarty and libjs-jquery-icheck
    applied ae1705aad57... chipsec: platform security assessment framework
    applied 5a31083b612... pahole: don't download vendored libbpf
    applied d93099003aa... libqb: Upgrade to 2.0.3
    applied cafcc65e746... opencv: fix build with protobuf-3.18 when dnn PACKAGECONFIG is enabled
    applied 6448ff99822... libeigen: backport fix for -Werror=class-memaccess issues when NEON is enabled
    applied bb3123bb879... phpmyadmin: upgrade 5.1.0 -> 5.1.1
    applied 71b93cb8156... cifs-utils: upgrade 6.13 -> 6.14
    applied 843b4e24b87... cmark: upgrade 0.30.1 -> 0.30.2
    applied ddf3442b62a... gpsd: upgrade 3.23 -> 3.23.1
    applied c9121e1ae49... README: mention linux-libc-dev:i386 for luajit on ubuntu-21.10
    applied 037f38cc68a... gpsd: inherit pkgconfig
    applied 3630c30185d... pahole: use MACHINE_ARCH
    applied e078ffd4ce1... libiio: depend on avahi only when network backed is used
    applied e9b3476ad99... gattlib: Place pkgconfig file in correct package
    applied 23dc4f060f3... gattlib: Upgrade to latest

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
