### PR TITLE
meta-xilinx: remove tree

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -16,12 +16,6 @@ dest_dir = meta-security
 branch = master
 last_revision = a85fbe980e5bc6acb50c0b2d520e65b98c7b3cd9
 
-[meta-xilinx]
-src_uri = git://git.yoctoproject.org/meta-xilinx
-dest_dir = meta-xilinx
-branch = master
-last_revision = 96f122efe48f239f7b5df4025acd5c98a61828b3
-
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky


### PR DESCRIPTION
See https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/48273 for
corresponding removal in openbmc and rationale.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
