### PR TITLE
honister updates

### DIFF
--- a/honister.conf
+++ b/honister.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = honister
-last_revision = f632403d1800363ac63a1ad5543278b82c659832
+last_revision = 4647e3ea3708d30eeb0149f6d5626c9576bff520
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,5 +20,5 @@ last_revision = fb77606aef461910db4836bad94d75758cc2688c
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = honister
-last_revision = f286eefb274ec261da51fd33b19ac92f8c40ee86
+last_revision = 883341e9ca18925b25e879866cca90bb57b552f2
 


### PR DESCRIPTION
meta-openembedded f632403d18 -> 4647e3ea37:
    applied 8739e7ae8ff5... lvm2: do not install systemd units/initscripts when building native SDK tools
    applied 2cd24bd20d44... msgpack-cpp: fix msgpack-cpp is a header only library
    applied ca687218bab1... imlib2: clarify license
    applied b712b3a1e394... xmlrpc-c: set precise BSD license
    applied 017674dbe8f9... dash: set precise BSD license
    applied 163d3489c5fc... sg3-utils: set precise BSD license
    applied 806ebd9314a0... nodejs: set precise BSD license
    applied bc97389fa8d3... libkcapi: set precise BSD license
    applied 9e0bf0c3b028... pcsc-lite: set precise BSD license
    applied 85bd22597824... python3-cryptography: set precise BSD license
    applied a9a50f06e1e0... python3-crypto-vectors: set precise BSD license
    applied c035aa28e069... python3-gevent: use system libraries instead of embedding
    applied 46026cd6ec5f... python3-gevent: update license
    applied f9707f700ec6... python3-lxml: set precise BSD license
    applied 2def8912aabd... python3-posix-ipc: set precise BSD license
    applied 8b5bfb2e008e... python3-posix-ipc: remove spurious dependencies
    applied 1a8108873029... python3-pyzmq: set precise BSD license
    applied a12eff7e3f6a... fb-test: fix SRC_URI
    applied 37b9a7a114e8... gattlib: Explicitly disable Python support
    applied ae34f8f8e4f7... googletest: Switch branch from master to main
    applied 7e8de0e57e66... python3-django: upgrade 3.2.5 -> 3.2.10
    applied b707efaf8aae... postgresql: fix CVE-2021-23214,CVE-2021-23222
    applied 678f72c3d3a8... openvpn: upgrade 2.5.4 -> 2.5.5
    applied 550ea1cab266... postfix: upgrade 3.6.2 -> 3.6.3
    applied 7fc335961a90... openipmi: upgrade 2.0.31 -> 2.0.32
    applied 6fc97431a9d7... libfile-slurper-perl: upgrade 0.012 -> 0.013
    applied 55cd5fa4cafe... libnet-dns-perl: upgrade 1.32 -> 1.33
    applied 89bf10d0cb8a... wireshark: update to latest stable 3.4.11
    applied 697808910bdc... apache2: upgrade 2.4.51 -> 2.4.52
    applied 4647e3ea3708... udisks2: upgrade 2.9.3 -> 2.9.4
poky f286eefb27 -> 883341e9ca:
    applied c7dba5edf1f4... wic: use shutil.which
    applied 4017ee6392d9... rust-cross: Fix directory not deleted for race glibc vs. musl
    applied c267650c86b8... maintainers.inc: fix up rust-cross entry
    applied f8de48283043... rust-cross: Replace TARGET_ARCH with TUNE_PKGARCH
    applied 6c93529a7d84... classes/meson: Add optional rust definitions
    applied e873b3ba278f... rootfs-postcommands: update systemd_create_users
    applied 001c21e32e9b... classes/crate-fetch: Ensure crate fetcher is available
    applied ca4ecac8dd31... buildhistory: Fix srcrevs output
    applied ea739bb98775... gmp: fix CVE-2021-43618
    applied 06e52ebd0757... wic: support rootdev identified by partition label
    applied 5934fef6659e... glibc: Fix i586/c3 support
    applied 846a29cb6e7f... linux-yocto/5.14: update to v5.14.18
    applied 27c85b25ad45... linux-yocto/5.10: update to v5.10.79
    applied c8646a2ffd15... systemd: update 249.3 -> 249.4
    applied 0946693d671a... systemd: update 249.4 -> 249.5
    applied f4ceafde0b03... systemd: upgrade 249.5 -> 249.6
    applied c6ff5420f926... systemd: update 249.6 -> 249.7
    applied 91c056ef2b5f... oeqa/utils/dump: Fix typo
    applied c8f57744c590... oeqa/parselogs: Fix quoting
    applied ac898a4b7b77... go: upgrade 1.16.8 -> 1.16.10
    applied 78fcbf9f6d54... scripts/checklayer/common.py: Fixed a minor grammatical error
    applied 3480ae13ed2d... libtool: Update patchset to match those submitted upstream
    applied c3666e4b6f4c... libtool: change the default AR_FLAGS from "cru" to "cr"
    applied 848bedfbb2df... vim: fix CVE-2021-3927 and CVE-2021-3928
    applied cbf8e1c83ad7... vim: fix CVE-2021-3968 and CVE-2021-3973
    applied ca066430d4ab... README.OE-Core.md: update URLs
    applied bff59a146b0e... recipetool: handle GitLab URLs like we do GitHub
    applied 6bbc9efbd330... recipetool: extend curl detection when creating recipes
    applied cb8ecfa6d773... boost: allow searching for python310
    applied 6dc28db9d3b0... boost: Fix build on arches with no atomics
    applied 3843d5ab80a4... patch.py: Initialize git repo before patching
    applied 823acda7cf7a... libdrm: upgrade 2.4.107 -> 2.4.108
    applied e9d4e26b4475... libdrm: upgrade 2.4.108 -> 2.4.109
    applied ff138c3ae9f9... updates for recent releases
    applied 86ae0ef3da48... bitbake: lib/pyinotify.py: Remove deprecated module asyncore
    applied 5a8d3e005af0... ncurses: fix CVE-2021-39537
    applied 0430d232607f... openssh: fix CVE-2021-41617
    applied 12b0635ae0cb... bind: fix CVE-2021-25219
    applied 8ea2981d0537... python3: upgrade 3.9.7 -> 3.9.9
    applied 60164ff8942d... linux-yocto/5.14: update to v5.14.21
    applied d726dc5e28b0... linux-yocto/5.10: update to v5.10.82
    applied 5a70a63af2e1... linux-yocto-rt/5.10: update to -rt56
    applied d1b54cfb2d9e... gcc: Add CVE-2021-37322 to the list of CVEs to ignore
    applied 992127a4dc9b... kern-tools: bug fixes and kgit-gconfig
    applied 309ab8e1330c... recipetool: Set master branch only as fallback
    applied f996b0f31803... selftest/devtool: Check branch in git fetch
    applied b498dc5a97fd... runqemu: check the qemu PID has been set before kill()ing it
    applied 4696bc59303a... cve-extra-exclusions: add db CVEs to exclusion list
    applied 607bd6410f3e... uboot-sign: fix the concatenation when multiple U-BOOT configurations are specified
    applied 4cfb6247a2bb... packagedata.py: silence a DeprecationWarning
    applied 869c4597bb1d... oe/license: implement ast.NodeVisitor.visit_Constant
    applied 4ce984316d03... license.bbclass: implement ast.NodeVisitor.visit_Constant
    applied cdc63882a9e2... systemd: Fix systemd-journal-gateway user/groups
    applied f0fbf8beaa33... gcc: Fix CVE-2021-35465
    applied 5d833a3d6ac4... gcc: Fix CVE-2021-42574
    applied ee5c54b75701... oeqa/selftest/bbtests: Use YP sources mirror instead of GNU
    applied 506f02545f2e... linux-yocto/5.10: update to v5.10.84
    applied 5f6014d4b767... linux-yocto/5.10: update to v5.10.85
    applied 520c9d1817b5... linux-yocto/5.10: update to v5.10.87
    applied bf46aeb5a76c... linux-firmware: upgrade 20211027 -> 20211216
    applied cedde50ff837... binutils: CVE-2021-42574
    applied 298a434af896... python3-pyelftools: Depend on debugger, pprint
    applied abd2189b32ac... xserver-xorg: upgrade 1.20.13 -> 1.20.14
    applied dc5344827410... bitbake: process: Do not mix stderr with stdout
    applied 9676f7252119... bitbake: fetch: npm: Quote destdir in run chmod command
    applied 0fb31e3238ea... bitbake: fetch: npm: Use temporary file for empty user config
    applied b41d8d65d597... bitbake: tests/fetch: Drop gnu urls from wget connectivity test
    applied a55e7effcbed... ref-manual: fix patch documentation
    applied ea55ecc61043... linux-yocto: add libmpc-native to DEPENDS
    applied 6f86ba22e897... bitbake: utils: Update to use exec_module() instead of load_module()
    applied b5224d5c530e... xserver-xorg: update CVE_PRODUCT
    applied fde023fd62bb... package_manager: ipk: Fix host manifest generation
    applied a8736744df83... grub2: fix CVE-2021-3981
    applied edc072b889f3... rpm: remove tmp folder created during install
    applied 3731372bd159... openssl: Add reproducibility fix
    applied d0c17bff6760... webkitgtk: Add reproducibility fix
    applied d6423d884276... vulkan-loader: inherit pkgconfig
    applied 849234d3ddb3... scripts: Update to use exec_module() instead of load_module()
    applied 2fbc7f5af18a... scripts/buildhistory-diff: drop use of distutils
    applied aab915c69aa8... epiphany: Update 40.3 -> 40.6
    applied c5d4475bb35d... lib/oe/reproducible: correctly set .git location when recursively looking for git repos
    applied 79a6976be6a6... cve-check: add lockfile to task
    applied f4ccd33a7b0a... xserver-xorg: whitelist two CVEs
    applied 48f3094c2496... rootfs-postcommands.bbclass: Make two comments use the new variable syntax
    applied 04399541c430... oeqa/sstate: Fix allarch samesigs test
    applied 8c111bb27c10... linux-yocto/5.10: update to v5.10.89
    applied c5f192e02f36... linux-yocto/5.14: fix arm 32bit -rt warnings
    applied 8376d6768f5d... linux-yocto/5.10/cfg: add kcov feature fragment
    applied f1f159e1e56d... linux-yocto/5.10: update to v5.10.90
    applied f31a661847da... libsndfile1: fix CVE-2021-4156
    applied 20d421b8020c... go: upgrade 1.16.10 -> 1.16.13
    applied bfd8a6ee411b... linux-yocto/5.10: update genericx86* machines to v5.10.87
    applied 883341e9ca18... linux-yocto/5.14: update genericx86* machines to v5.14.21

openbmc-subtree update -c honister.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
