### PR TITLE
meta-security update for master

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -14,7 +14,7 @@ last_revision = 9eb4879cf4a289607ec7493577adb0ba97367821
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = a85fbe980e5bc6acb50c0b2d520e65b98c7b3cd9
+last_revision = c20b35b5279988fb244d4de5ba5a049404ad440e
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky


### PR DESCRIPTION
Submitted to Gerrit as:
    https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/50554

meta-security a85fbe980e -> c20b35b527:
    applied 01bdc2918cfe... swtpm: update to 0.6.1
    applied 7f9a5b311e98... recipes-security/chipsec: platform security assessment framework
    applied 30a5e16b75a6... python3-fail2ban: fix build failure and cleanup
    applied e81c15f851ca... sssd: re-package to fix QA issues
    applied 2bc849ada34e... meta-parsec/README: remove rust layer req.
    applied 14e1db4ce886... Parsec service. Update PACKAGECONFIG definitions and README.md
    applied e5e54135da21... opendnssec: blacklist do to ldns being blacklisted
    applied 8f045875fb54... apparmor: Add a python 3.10 compatability patch
    applied 5d2afb321cf8... tpm2-tools: update to 5.2
    applied b5e277022b4a... openssl-tpm-engine: fix build issue with openssl 3
    applied d77b7765e710... tpm2-openssl: add new pkg
    applied 8215ed27aa5b... tpm2-pkcs11: update to 1.7.0
    applied 7e27eb5fca7a... recipes: Update SRC_URI branch and protocols
    applied 696651d0c322... tpm2-tss: fix fapi package config
    applied b654040fad92... sssd: Create /var/log/sssd in runtime
    applied f6fa9dc1c9eb... bastille: Create /var/log/Bastille in runtime
    applied 4c19c83ee84e... python3-fail2ban: remove /run
    applied 05ee41d3a5c5... apparmor: fix warning of remove operator combined with +=
    applied 59295103f1f8... openssl-tpm-engine: fix warning for append operator combined with +=
    applied e4a49814e101... meta-parsec/README.md: fix for append operator combined with +=
    applied 9bf5c504d196... tpm2-pkcs11: update to 1.7.0
    applied e740a30c102c... libest: does not build with openssl 3.x
    applied 587c92251d7d... clamav: fix useradd warning
    applied cb7778e5ef33... python3-fail2ban: update to tip
    applied 126860dac30d... dm-verity-img.bbclass: Fix wrong override syntax for CONVERSION_DEPENDS
    applied e3b50febf8d4... tpm2-pkcs11: backport openssl 3.x build fixes
    applied 147ed69a1927... packagegroup-security-tpm2: drop ibmswtpm2
    applied d6f8b795a81f... meta-integrity: drop strongswan bbappends
    applied c20b35b52799... meta-tpm: drop strongswan bbappends

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree \
    meta-security --shortlog
