### PR TITLE
dunfell subtree update

### DIFF
--- a/dunfell.conf
+++ b/dunfell.conf
@@ -92,7 +92,7 @@ last_revision = 168440a0f1c89fc8ef6cabea033c5611d323df89
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = dunfell
-last_revision = 4a0d93d250576177e1237fa559f55c4f9d371809
+last_revision = ab9fca485e13f6f2f9761e1d2810f87c2e4f060a
 
 [meta-openpower]
 src_uri = https://gerrit.openbmc-project.xyz/openbmc/meta-openpower
@@ -128,13 +128,13 @@ last_revision = 2a53c3569af7fa1b0e1736d179e8178ffecf427d
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = dunfell
-last_revision = 59c2d6f7a8b1239bd7b587b9180c2a55f9c695a2
+last_revision = 934064a01903b2ba9a82be93b3f0efdb4543a0e8
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = dunfell
-last_revision = 6466c6fb02f36f459b06d434484df26e083f3489
+last_revision = b76698c788cb8ca632077a972031899ef15025d6
 
 [meta-x86]
 src_uri = https://gerrit.openbmc-project.xyz/openbmc/meta-x86
@@ -158,5 +158,5 @@ last_revision = 7eef85ee0d2e6f8100c06c0f9a9cb52c941ecd50
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = dunfell
-last_revision = ed4791c8b05d02edb783359656376216b98c1c49
+last_revision = bba323389749ec3e306509f8fb12649f031be152
 


### PR DESCRIPTION
poky ed4791c8b0 -> bba3233897:
    applied e2cb601ab6f6... glibc: Security fix CVE-2021-33574
    applied ef3c563a4fa2... glibc: Security fix for CVE-2021-38604
    applied fa25ed8a6aba... gnupg: upgrade 2.2.20 -> 2.2.21
    applied 5b3ddc2a5064... gnupg: update 2.2.21 -> 2.2.22
    applied 8fb30a670589... gnupg: uprev 2.2.22 -> 2.2.23
    applied 045071f7124c... gnupg: update 2.2.23 -> 2.2.26
    applied 02108b6dbc78... gnupg: upgrade 2.2.26 -> 2.2.27
    applied e142f4ebfba1... qemu: Security fix CVE-2020-25085
    applied ea562eaec5c7... qemu: Security fix CVE-2020-25624
    applied c00a882bd661... Qemu: Security fix for CVE-2020-25625/2021-3409/2020-17380
    applied b3bf5ccd83f5... qemu: Security fix for CVE-2020-29443
    applied f721d78703d8... qemu: Security fix CVE-2021-20221
    applied 474c37c17ee8... qemu: fix CVE-2021-20181
    applied 4bd52d64c958... qemu: fix CVE-2021-3416
    applied 4ed9972582fc... qemu: fix CVE-2021-20257
    applied 0d253da7204b... qemu: Security fix CVE-2021-3544
    applied 189108ac7441... qemu: Security fixes CVE-2021-3545/6
    applied d56b8f6f762f... qemu: fix CVE-2021-3527
    applied f63635a30da4... qemu: fix CVE-2021-3582
    applied 4d8b5c4d70db... qemu: fix CVE-2021-3607
    applied 6bcc4029d4ea... qemu: fix CVE-2021-3608
    applied 420d5551b2c3... rpm: Add fix for CVE-2021-20266
    applied 50204d091bfb... binutils: Security fix for CVE-2021-3549
    applied b06370cc2dd3... binutils: Security fix for CVE-2020-16593
    applied f6f391b4af92... openssl: update from 1.1.1k to 1.1.1l
    applied def634eeaee2... Use the label provided when formating a dos partition
    applied 9b62e6b83446... lzo: add CVE_PRODUCT
    applied e7eeef5ab7b9... utils: Reduce the number of calls to the "dirname" command
    applied 3e75c5d0b481... tcf-agent: fetching over git:// no longer works
    applied 660de7613484... mklibs-native: drop deprecated cpp17 exceptions
    applied 6918a0298ace... image_types: Restore pre-btrfs-tools 4.14.1 mkfs.btrfs shrink behavior
    applied 1f4497167a82... linux-yocto/5.4: update to v5.4.142
    applied b90687ad24d2... qemurunner.py: print output from runqemu/qemu-system in stop()
    applied 4e28505e23cd... qemurunner.py: handle getOutput() having nothing to read
    applied ffcdd251ff1b... parselogs.py: ignore intermittent CD/DVDROM identification failure
    applied bdd30be1a381... selftest: disable virgl headless test
    applied 7c1bc9065436... documentation: prepare for 3.1.11 release
    applied 7721fa8185be... poky.conf: Bump version for 3.1.11 release
    applied 6fef2a1c2ca8... sdk: Decouple default install path from built in path
    applied 043cb19a0d5d... cpio: backport fix for CVE-2021-38185
    applied 2a01b629de38... lz4: Security Fix for CVE-2021-3520
    applied b35ee4a64ea3... vim: add option to disable NLS support
    applied 60cfe38b513d... layer.conf: fix syntax error in PATH setting
    applied cf9e68db3165... gdk-pixbuf: fix CVE-2021-20240
    applied 2c00edba7fc5... xdg-utils: Add fix for CVE-2020-27748
    applied 468ac59e9cc8... lighttpd: Add patch for reuse large memory chunks
    applied 7369788009e0... oeqa/runtime/parselogs: Make DVD ata error apply to all qemux86 machines
    applied d1a90797828b... rt-tests: set branch name in SRC_URI
    applied 871a37352780... dbus: upgrade 1.12.16 -> 1.12.18
    applied 955ae70225a4... dbus-test: upgrade 1.12.16 -> 1.12.18
    applied 9317b4771cbf... dbus-test: Remove EXTRA_OECONF_X configs
    applied 65ccb3015930... dbus,dbus-test: Move common parts to dbus.inc
    applied 50ea49f3d97a... dbus: upgrade 1.12.18 -> 1.12.20
    applied 6aa55dd279b1... flex: Add CVE-2019-6293 to exclusions for checks
    applied 7f73831fde4c... go: Exclude CVE-2021-29923 from report list
    applied d3f4731220e6... xserver-xorg: Security fix for CVE-2020-14360/-25712
    applied 9bae357b12a6... go: Several Security fixes
    applied 80b8fc829f80... build-appliance-image: Update to dunfell head revision
    applied 67dbe8a1c2b4... poky: Use SDKPATHINSTALL instead of SDKPATH
    applied 74b22db6879b... build-appliance-image: Update to dunfell head revision
    applied 2bd92c7e4772... bitbake: tests/fetch2: Use our own git server for dtc test repo
    applied 603839904814... libgcrypt: Security fix CVE-2021-33560
    applied eb3e28fa18a8... apr: Security fix for CVE-2021-35940
    applied 874fe76b00f7... libsndfile: Security fix for CVE-2021-3246
    applied 81bb24c0f764... qemu: Security fix CVE-2020-12829
    applied 5b85cb6b51fa... qemu: Security fix for CVE-2020-27617
    applied 830f96a9c3ac... qemu: Security fix for CVE-2020-28916
    applied acf57727fc71... qemu: fix CVE-2021-3682
    applied a1ad0499b433... nettle: Security fix for CVE-2021-3580
    applied 33d7811e07e0... curl: Fix CVE-2021-22946 and CVE-2021-22947, whitelist CVE-2021-22945
    applied 584252a0dc45... nettle: Security fix for CVE-2021-20305
    applied 5d5ec38952e0... squashfs-tools: fix CVE-2021-40153
    applied b2ec15322526... tar: ignore node-tar CVEs
    applied 9e3fb5271683... vim: Backport fix for CVE-2021-3770
    applied 853b007f6238... iputils: Fix regression of arp table update
    applied 039bbc6cc11a... linux-yocto/5.4: update to v5.4.143
    applied e8e54115f704... linux-yocto/5.4: update to v5.4.144
    applied 09ac5229955a... rpm: Handle proper return value to avoid major issues
    applied 065ca6b7b04d... useradd: Ensure preinst data is expanded correctly in pkgdata
    applied dbdb61464213... bash: Ensure deterministic build
    applied 1a496eb85cf9... Update mailing list address
    applied c2ee49ce117d... core-image-sato: Fix runqemu error for qemuarmv5
    applied 1f66c623de8d... wic: keep rootfs_size as integer
    applied 5df4fb1fa108... testimage: symlink the task log and qemu console log to tmp/log/oeqa
    applied fe5c36eb1edc... libsoup-2.4: remove obsolete intltool dependency
    applied c0278562919c... connman: add CVE_PRODUCT
    applied 93efbb5548ee... bitbake: server: Fix early parsing errors preventing zombie bitbake
    applied 7af78d74ef21... bitbake: ui/taskexp: Improve startup exception handling
    applied f7e64d59cb8e... bitbake: ui/taskexp: Fix to work with empty build directories
    applied 5b13c1d8ab38... bitbake: bitbake: bitbake-layers: add skip reason to output
    applied 674fa8dc46dc... bitbake: build: Match markup to real function name
    applied 55d4a252a8ce... bitbake: build: Handle SystemExit in python tasks correctly
    applied 0e8c6cad0800... bitbake: process: Don't include logs in error message if piping them
    applied 4de265915c0a... bitbake: build: Avoid duplicating logs in verbose mode
    applied cbcdc1e02ed5... bitbake: build: Catch and error upon circular task references
    applied 406c1b498f3d... bitbake: data_smart: Improve error display for handled exceptions
    applied 3da80a8a9e95... bitbake: cookerdata: Improve missing core layer error message
    applied 892977a86239... bitbake: cookerdata: Show error for no BBLAYERS in bblayers.conf
    applied ba06c29f117a... bitbake: bitbake-worker: Improve error handling
    applied 75c8a5f56664... bitbake: cookerdata: Show a readable error for invalid multiconfig name
    applied 28f080629b51... bitbake: build/msg: Cleanup verbose option handling
    applied 32308c930f4e... vim: fix CVE-2021-3778
    applied 914ee53a873a... openssh: Fix CVE-2021-28041
    applied 81dc02cb74b2... mtd-utils: upgrade 2.1.1 -> 2.1.2
    applied 3d5a3e009a6f... mtd-utils: upgrade 2.1.2 -> 2.1.3
    applied f3452bf99367... systemd: Add fix for systemd-networkd crash during free
    applied 132ad7a00bc0... common-licenses: add "Unlicense" license file
    applied b1da6a371d0f... bzip2: Update soname for libbz2 1.0.8
    applied 1d175bfd8526... libsamplerate0: Set correct soname for 0.1.9
    applied ff75921e81b3... pybootchart: Avoid divide by zero
    applied 2f3579b7212b... oeqa/qemurunner: Use oe._exit(), not sys.exit()
    applied 53983505d78a... libc_package/buildstats: Fix python regex quoting warnings
    applied 51fe6c9a07f1... rm_work.bbclass: Fix for files starting with -
    applied e22125b0c20b... oeqa/selftest/gotoolchain: Fix temp file cleanup
    applied dd1f464f36e0... oeqa/buildproject: Ensure temp directories are cleaned up
    applied b47125666fe4... glew: Stop polluting /tmp during builds
    applied d2f1a20a19a8... bitbake: test/fetch: Update urls to match upstream branch name changes
    applied c35f34361e94... bitbake: compat.py: remove file since it no longer actually implements anything
    applied 3e3434ee1022... bitbake: bitbake: correct the collections vs collections.abc deprecation
    applied d3ace96aec91... bitbake: bitbake: fix regexp deprecation warnings
    applied e54b102483e9... bitbake: bitbake: do not import imp in layerindexlib
    applied c71964cd2980... bitbake: bitbake: adjust parser error check for python 3.10 compatibility
    applied 372e40092b4d... bitbake: bitbake: correct deprecation warning in process.py
    applied a07f53efa876... bitbake: hashserv: let asyncio discover the running loop
    applied 9827758ebe3c... bitbake: fetch2/git: Avoid races over mirror tarball creation
    applied 9c007cb1e35f... bitbake: fetch2/git: Use os.rename instead of mv
    applied e86adf76ab56... ffmpeg: Add fix for CVEs
    applied b4866fc0f24f... linux-yocto/5.4: update to v5.4.149
    applied 9fc32336f45a... linux-yocto/5.4: update to v5.4.150
    applied 79d9e24e55cd... linux-yocto/5.4: update to v5.4.153
    applied 7e71b018512e... e2fsprogs: update to 1.45.6
    applied f21c479c3a68... e2fsprogs: upgrade 1.45.6 -> 1.45.7
    applied e0cb0077e266... weston: Use systemd notify,
    applied fed017998a3e... multilib: Avoid sysroot race issues when multilib enabled
    applied 9036ad0ab326... oeqa/manual: Fix no longer valid URLs
    applied ac19191a46de... binutils: Fix a missing break in case statement
    applied d1bb485d053a... scriptutils.py: Add check before deleting path
    applied 1501d447cf96... rng-tools: add systemd-udev-settle wants to service
    applied 8f637c5d4229... tar: filter CVEs using vendor name
    applied 0352c571019a... oeqa/selftest/sstatetests: fix typo ware -> were
    applied 6f9508c2743d... patch.bbclass: when the patch fails show more info on the fatal error
    applied b6869250d302... libpsl: Add config knobs for runtime/builtin conversion choices
    applied e2c46b23d325... gcc: fix missing dependencies for selftests
    applied 5e2c22d7ee52... m4: Do not use SIGSTKSZ
    applied e155627e5ed4... gpgme: Use glibc provided closefrom API when available
    applied aed177cb91fd... util-linux: disable raw
    applied 847395f46d49... pseudo: Fix to work with glibc 2.34 systems
    applied 304b63767059... pseudo: Update with fcntl and glibc 2.34 fixes
    applied 54053aa4722f... nativesdk-pseudo: Fix to work with glibc 2.34 systems
    applied 786250e9874e... uninative: Improve glob to handle glibc 2.34
    applied 83b827e3d683... uninative: Upgrade to 3.3, support glibc 2.34
    applied 63b5e198b4e8... package: Ensure pclist files are deterministic and don't use full paths
    applied 230e03300d5b... mesa: Ensure megadrivers runtime mappings are deterministic
    applied 210be5440b9b... gnupg: Be deterministic about sendmail
    applied 45ef46bb4c22... util-linux: Fix reproducibility
    applied 4aa06e862270... libtool: Fix lto option passing for reproducible builds
    applied 97b565358555... libtool: Allow libtool-cross to reproduce
    applied 7b13a3163202... gobject-introspection: Don't write $HOME into scripts
    applied f34727509abf... externalsrc: Work with reproducible_build
    applied e007e0f5b91e... externalsrc: Fix a source date epoch race in reproducible builds
    applied 73483b4fdb76... libxml2: Use python3targetconfig to fix reproducibility issue
    applied 4d4dd6b7686e... libnewt: Use python3targetconfig to fix reproducibility issue
    applied 6307f19fc47c... python3: Add a fix for a make install race
    applied a1481f2e9c69... target/ssh.py: add HostKeyAlgorithms option to test commands
    applied a28d37580a1a... uninative: Upgrade to 3.4
    applied 28e4d07f4977... poky.conf: Add fedora 34 as a supported distro
    applied 78fe96f3edf9... poky.conf: Add debian 11 as a supported distro
    applied f706d3a2cbb8... rpm: Deterministically set vendor macro entry
    applied 0e6f0e2c6776... reproducible_build: Work around caching issues
    applied cf167fa2735c... classes/reproducible_build: Use atomic rename for SDE file
    applied 3855395469fe... selftest/reproducible: adjust exclusion list for dunfell
    applied 5f26494b3a5e... poky.yaml: fedora33: add missing pkgs
    applied 482a84bf621b... curl: Whitelist CVE-2021-22897
    applied 1f3c5353504e... vim: fix 2021-3796
    applied bc73d2c63b48... sstate: fix touching files inside pseudo
    applied 4b863f98e271... devtool: fix modify with patches in override directories
    applied 3f2e26f122e5... sstate: don't silently handle all exceptions in sstate_checkhashes
    applied f81f505f131b... base: Clean up unneeded len() calls
    applied cf5c5636d802... base: Use repr() for printing exceptions
    applied b967cce9f4ba... bitbake.conf: Add gpg-agent as a host tool
    applied 0e3391131391... oe/license: implement ast.NodeVisitor.visit_Constant
    applied 990c49917662... license.bbclass: implement ast.NodeVisitor.visit_Constant
    applied 59ad5783a596... oe/utils: log exceptions in ThreadedWorker functions
    applied abcb68effdbd... reproducible_build: Drop obsolete sstate workaround
    applied 2de98cf4b997... testimage: fix unclosed testdata file
    applied 03a5e65cdd70... oeqa/runtime: load modules using importlib
    applied 62c874086a9f... oeqa/runtime: search sys.path explicitly for modules
    applied d2ea9e1f7d58... oeqa/runtime/parselogs: modified drm error in common errors list
    applied 52b3006e705e... mirrors.bbclass: remove dead infozip mirrors
    applied b7799dd102eb... waffle: old website is down, update to new project URLs
    applied 173a40ec3986... stress-ng: convert to git, website is down
    applied 7de484c47a3a... stress-ng: improve reproducibility
    applied 2ff0494ae930... git: Fix determinism issue
    applied cc803231268e... linux-firmware: upgrade 20210511 -> 20210818
    applied caee08d8f78f... linux-firmware: upgrade 20210818 -> 20210919
    applied 54eba8c3384e... wireless-regdb: upgrade 2021.04.21 -> 2021.07.14
    applied 1aad796c7882... wireless-regdb: upgrade 2021.07.14 -> 2021.08.28
    applied 7158bf077538... ca-certificates: update 20210119 -> 20211016
    applied 1986409a2b9a... tzdata: upgrade 2021a -> 2021d
    applied c9e318b3e44d... tzdata: update 2021d -> 2021e
    applied 0810ac6b926c... bitbake: fetch/git: Handle github dropping git:// support
    applied 1354f0f0ab00... bitbake: tests/fetch2: Fix quoting warning
    applied 96a85854fedf... bitbake: tests/fetch: Update github urls
    applied ea2d42c2b110... bitbake: tests/fetch: Update pcre.org address after github changes
    applied afe0ef0a074b... scripts/convert-srcuri: Backport SRC_URI conversion script from master branch
    applied 07be05c69896... meta: Add explict branch to git SRC_URIs, handle github url changes
    applied 31007eb03e22... meta/scripts: Manual git url branch additions
    applied 701e299b9183... bitbake: fetch/wget: Add timeout for checkstatus calls (30s)
    applied 201d64e90a06... poky.conf: Bump version for 3.1.12 release
    applied 7943e817c45a... ref-system-requirements.rst: Add Debian 11 to list of supported distros
    applied 19f9f7f003e7... ref-system-requirements.rst: Add Fedora 34 to list of supported distros
    applied 76c841d8a838... documentation: prepare for 3.1.12 release
    applied 25cf12590903... oeqa: reproducible: Fix test not producing diffs
    applied 712b6f51f9f3... webkitgtk: Fix reproducibility in minibrowser
    applied fe02ef170d0f... python3-magic: add the missing rdepends
    applied e3fd874a5b49... python3-magic: add missing DEPENDS
    applied 47403ee6a208... linunistring: Add missing gperf-native dependency
    applied a88380a4e2b8... pseudo: Add in ability to flush database with shutdown request
    applied fca4b3b10691... pseudo: Add fcntl64 wrapper
    applied 53226d9c8713... piglit: upgrade to latest revision
    applied 8392750d4fde... mirrors: Add uninative mirror on kernel.org
    applied c989f6f4e038... sstate: another fix for touching files inside pseudo
    applied 54560698c63c... sstate: Ensure SDE is accounted for in package task timestamps
    applied 116b22a1ce02... sstate: Avoid deploy_source_date_epoch sstate when unneeded
    applied 0d6ebaf8ff32... reproducible_build: Remove BUILD_REPRODUCIBLE_BINARIES checking
    applied 25b072541c2f... selftest/reproducible: add webkitgtk back to exclusion list for dunfell
    applied 4b36bbb24396... mirrors: Add kernel.org sources mirror for downloads.yoctoproject.org
    applied 0839888394a6... build-appliance-image: Update to dunfell head revision
    applied b409a428c1e8... bitbake: command: Ensure exceptions inheriting from BBHandledException are visible
    applied 1db38c5a1895... bitbake: tinfoil: When sending commands we need to process events
    applied 349e53d3cc89... bitbake: process/knotty: Improve early exception handling
    applied 37cc520f287b... linux-yocto/5.4: update to v5.4.154
    applied 7b8020e2820e... linux-yocto/5.4: update to v5.4.155
    applied 9071e52286dd... linux-yocto/5.4: update to v5.4.156
    applied e4e3cfdf9c14... linux-yocto/5.4: update to v5.4.158
    applied b2089f012a77... linux-firmware: upgrade 20210919 -> 20211027
    applied 409df675a84d... python3: upgrade 3.8.11 -> 3.8.12
    applied 0beeed7d253a... Revert "vim: fix 2021-3796"
    applied 882120387307... vim: fix CVE-2021-3796, CVE-2021-3872, and CVE-2021-3875
    applied 695c0cd68074... vim: add patch number to CVE-2021-3778 patch
    applied 3d9e8146d0f4... vim: fix CVE-2021-3927 and CVE-2021-3928
    applied 1a5fb730ac92... gmp: fix CVE-2021-43618
    applied e006c87e225a... git: fix CVE-2021-40330
    applied 82b03a6837a3... scripts/oe-package-browser: Handle no packages being built
    applied 30b0a2e1c551... scripts/lib/wic/help.py: Update Fedora Kickstart URLs
    applied 47d64781265b... glibc-version.inc: remove branch= from GLIBC_GIT_URI
    applied 89a0148b509d... libpcre/libpcre2: correct SRC_URI
    applied e1e7e3c7ba98... cups: Fix missing installation of cups sysv init scripts
    applied 44ce6c4a5d6c... os-release: Add DISTRO_CODENAME as vardeps for do_compile
    applied 6e1c3966d119... lrzsz: Use Cross AR during compile
    applied 22c84eea241d... oeqa: fix warnings for append operators combined with +=
    applied e24afc304af2... reproducible_build/package_XXX: Ensure SDE task is in dependency chain
    applied 46f68b512132... make-mod-scripts: pass CROSS_COMPILE to configure and build
    applied 8ee284f8b2b7... systemd: add packageconfig for wheel-group
    applied 104c0e6938c9... openssh: Improve LICENSE to show BSD license variants.
    applied de97f0eccc21... openssh: remove redundant BSD license
    applied f18d2289d02a... bitbake: cooker: Ensure reparsing is handled correctly
    applied d875c5e57b91... bitbake: bblayers/action: When adding layers, catch BBHandledException
    applied 090075eb3a74... glib-2.0: Add security fixes
    applied 1f2cf291e767... busybox: Fix for CVE-2021-42374
    applied 15d764e697b1... busybox: Fix for CVE-2021-42376
    applied 0e5c82c4c929... vim: fix CVE-2021-3968 and CVE-2021-3973
    applied 80132fb2df0e... ncurses: Fix for CVE-2021-39537
    applied 643c3b7bf36a... libsolv: update tag for missing CVEs
    applied 3a71f5c1bf79... bind: update to 9.11.33
    applied 215a1a82379e... bind: update to 9.11.34
    applied 652e053d0c3f... bind: update to 9.11.35
    applied fc34eadb5660... libdnf: Backport bugfix for upgrade calc
    applied 57b3bf09e191... dnf: Backport bugfix for upgrade
    applied 1a6bf7311989... libunwind: Backport a fix for -fno-common option to compile
    applied 038e25aec3b7... buildhistory: Fix srcrevs output
    applied 746b301d37f9... oeqa/parselogs: Fix quoting
    applied 11d99fba1ff4... cmake: FindGTest: Add target for gmock library
    applied 69f5804c8abe... scripts/checklayer/common.py: Fixed a minor grammatical error
    applied 02bd7ece750c... README.OE-Core.md: update URLs
    applied cf5a00721f72... documentation: conf.py: explicit which version of bitbake objects.inv is used
    applied bdfabf040989... available release updates
    applied 80306758c623... remove reference to BB_SETSCENE_VERIFY_FUNCTION2
    applied 56485d82f670... poky.conf: Bump version for 3.1.13 release
    applied 947e5ff11c56... cve-extra-exclusions: add db CVEs to exclusion list
    applied ec21b227cdd2... libgcrypt: solve CVE-2021-33560 and CVE-2021-40528
    applied 22767ef3986a... gcc: Add CVE-2021-37322 to the list of CVEs to ignore
    applied 8967fcbcc4c2... busybox: Fix multiple security issues in awk
    applied b8623317df2f... wic:direct.py: ignore invalid mountpoints during fstab update
    applied 9bb220ccc13a... lttng-modules: do not search in non-existing folder during install
    applied 75dde71fba75... runqemu: check the qemu PID has been set before kill()ing it
    applied 963a35872c5a... recipetool: Set master branch only as fallback
    applied 25e51ec82ac6... selftest/devtool: Check branch in git fetch
    applied 38793eecdadd... selftest: skip virgl test on centos 8 entirely
    applied 795339092f87... build-appliance-image: Update to dunfell head revision
    applied 30231b235487... bluez: fix CVE-2021-0129
    applied f4a6761f471f... openssh: Fix CVE-2021-41617
    applied bd0708041517... openssh: Whitelist CVE-2016-20012
    applied 9564dc31cb90... vim: fix CVE-2021-4069
    applied 1e13a3f9146b... inetutils: fix CVE-2021-40491
    applied 11880c698790... dropbear: Fix CVE-2020-36254
    applied 3e9902aa6c12... bootchart2: remove wait_boot logic
    applied 4750894a6a1f... linux-yocto/5.4: update to v5.4.159
    applied f06e7a026d11... linux-yocto/5.4: update to v5.4.162
    applied d19c2eba9825... linux-yocto/5.4: update to v5.4.163
    applied b2c0b6caf913... linux-yocto/5.4: update to v5.4.165
    applied 8a1fc484cca4... linux-yocto/5.4: update to v5.4.167
    applied 846e457b3580... gstreamer1.0: fix failing ptest
    applied 98d21218fcf1... selftest: skip virgl test on fedora 34 entirely
    applied 56e9d560b0b9... releases: update to include 3.1.13
    applied ee0220a2bb4d... documentation: further updates for 3.1.13
    applied 0490ee594486... ref-manual: fix patch documentation
    applied 6e6ede294c33... bitbake: cooker/command: Add a dummy event for tinfoil testing
    applied c55481b8066a... grub: fix CVE-2020-14372 and CVE-2020-27779
    applied e1fbe6c4a340... linux-firmware: upgrade 20211027 -> 20211216
    applied 2b65abb2554a... libpcre2: update SRC_URI
    applied 468588819ef1... openssl: Add reproducibility fix
    applied 9e75884e0ade... oeqa/selftest/bbtests: Use YP sources mirror instead of GNU
    applied b72fe527c9bd... oeqa/selftest/tinfoil: Update to use test command
    applied 545719898425... weston: Backport patches to always activate the top-level surface
    applied cfd64997c473... scripts/buildhistory-diff: drop use of distutils
    applied c1599e44e1cb... selftest: skip virgl test on fedora 35
    applied 6a3354025c8e... scripts: Update to use exec_module() instead of load_module()
    applied d62ff889632c... lib/oe/reproducible: correctly set .git location when recursively looking for git repos
    applied e2aa71277584... asciidoc: properly detect and compare Python versions >= 3.10
    applied 3432003435a2... linux-yocto/5.4: update genericx86* machines to v5.4.158
    applied cbc25057f1b4... bitbake: utils: Update to use exec_module() instead of load_module()
    applied 4a14c922d8fb... bitbake: tests/fetch: Drop gnu urls from wget connectivity test
    applied 34ba446157fd... valgrind: skip flakey ptest (gdbserver_tests/hginfo)
    applied ee9345f86406... oeqa/selftest/cases/tinfoil.py: increase timeout 60->120s test_wait_event
    applied ee62d4540e6a... cve-update-db-native: use fetch task
    applied 6ec2230291b6... cve-check: add lockfile to task
    applied 192834adc0f8... xserver-xorg: update CVE_PRODUCT
    applied 2be5df91820a... wic: misc: Do not find for executables in ASSUME_PROVIDED
    applied e1f86e776157... wic: use shutil.which
    applied 07755db69908... expat: Update HOMEPAGE to current url
    applied 1e4665204b6e... xserver-xorg: whitelist two CVEs
    applied 7a4fa2864255... parselogs: add a couple systemd false positives
    applied 6348d2d8a03a... glibc: Add fix for data races in pthread_create and TLS access
    applied 95491a12eacd... expat fix CVE-2022-22822 through CVE-2022-22827
    applied b618e57f7981... expat: fix CVE-2021-45960
    applied 8c58e222ea49... expat: fix CVE-2021-46143
    applied ce2db1116c10... speex: fix CVE-2020-23903
    applied f439e82404a5... linux-yocto/5.4: update to v5.4.169
    applied dadebc61f494... linux-yocto/5.4: update to v5.4.170
    applied ab23ceac1207... linux-yocto/5.4: update to v5.4.171
    applied 243f90cb86e5... linux-yocto/5.4: update to v5.4.172
    applied 744c593c3dc8... kernel: introduce python3-dtschema-wrapper
    applied c72a9d0a6db9... lttng-tools: Add missing DEPENDS on bison-native
    applied e256885889fd... Revert "weston: Use systemd notify,"
    applied 2bfe7e096d7a... bitbake: hashserv: specify loop for asyncio in python < 3.6
    applied d752cbcbbeee... poky.conf: Bump version for 3.1.14 release
    applied bba323389749... build-appliance-image: Update to dunfell head revision
meta-raspberrypi 59c2d6f7a8 -> 934064a019:
    applied c4d091732cd7... recipes: Update SRC_URI protocols for github
    applied 2e704f5ef61e... 99-com.rules: fix error invalid substitution type
    applied 934064a01903... linux-firmware-rpidistro: Use buster branch instead of master
meta-security 6466c6fb02 -> b76698c788:
    applied b76698c788cb... linux-%_5.%.bbappend: drop recipe
meta-openembedded 4a0d93d250 -> ab9fca485e:
    applied 0fc9d446d173... xterm: Security fix for CVE-2021-27135
    applied b9fe34b1ad28... tcpdump: Exclude CVE-2020-8036 from check
    applied ca550956aa91... apache2: upgrade 2.4.46 -> 2.4.48
    applied 09b22a0f1073... dlt-daemon: update to 2.18.5
    applied 4592a36250ed... dlt-daemon: fix build failure when dlt-dbus is enabled, due to missing service file.
    applied 638f787f746e... dlt-daemon: fix build with upstream-proposed patch for MUSL libc
    applied 5d6945d7807b... dlt-daemon: superseed upstream pr #238 patch with pr #245 due to unexpected behaviour
    applied 3d6a451571c5... dlt-daemon: update to new release 2.18.6
    applied 5472c05130af... dlt-daemon: update from 2.18.6 to 2.18.7
    applied 9ce3df8c2a10... c-ares: upgrade 1.16.0 -> 1.16.1
    applied 5c347d8ce425... nss: Two Security fixes CVE-2020-6829 and 12400
    applied 892b724cd147... stunnel: upgrade 5.56 -> 5.57
    applied 06d80777f478... krb5: fix CVE-2021-36222
    applied 2e7e98cd0cb8... dnsmasq: Security fix CVE-2021-3448
    applied b06724bc274f... c-ares: Add fix for CVE-2021-3672
    applied 5368c7c63d07... dstat: Add missing python-six runtime dependency
    applied df1a3371d05f... apache2: upgrade 2.4.48 -> 2.4.49
    applied 3cf22d15885c... tcpdump: Update CVE-2020-8037 tag
    applied c1913c367fe2... gattlib: remove includedir from base package
    applied 814eec96c2a2... gattlib: Place pkgconfig file in correct package
    applied 98ccbca49165... Apache: Several CVE fixes
    applied 6be10fe608c0... redis: update to 5.0.14
    applied d10d52aef959... pm-qa: fix paths for shell scripts
    applied f8a2a7e41ac8... gst-shark: Define SRCREV_FORMAT
    applied 9298852a912b... android-tools: Define SRCREV_FORMAT
    applied 5dd554753d9e... spirv-tools: Define SRCREV_FORMAT
    applied 46eb172b64ee... grpc: Define SRCREV_FORMAT
    applied 4b8f554f4d19... drdb-utils: Define SRCREV_FORMAT
    applied ca35402be567... keyutils: fix install path
    applied 7889158dcd18... python3-fasteners: update 0.15 -> 0.16.3
    applied 59bff77ad0b3... recipes: Update SRC_URI branch and protocols
    applied bcf93614a0f8... nss: Fix CVE-2020-12403
    applied c618e90cdad6... lmsensors: do not depend on lmsensors-isatools on non-x86
    applied d9717dea5355... sdbus-c++: don't fetch googletest during do_configure
    applied e0e79bbde23f... jansson: whitelist CVE-2020-36325
    applied 00ad99f4f9a0... dovecot: Fix CVE-2020-12100
    applied 7804c8e5bd29... dovecot: Fix CVE-2020-12673
    applied fba8ff0d9163... dovecot: Fix CVE-2020-12674
    applied 69f94af4d912... brotli: add patch to fix CVE-2020-8927
    applied 6025097d083a... c-ares: switch from master to main
    applied 82264cbf0b69... nss: Fix CVE-2021-43527
    applied ddaf5f92cc55... libmicrohttpd: Add patch to fix CVE-2021-3466
    applied 197453e127c7... postgresql: Update to 12.9
    applied 95969f0f5f42... dovecot: refresh patches
    applied 544bcd09f59a... postfix: fix build with glibc 2.34
    applied ab9fca485e13... postfix: upgrade 3.4.12 -> 3.4.23

openbmc-subtree update -c dunfell.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
