### PR TITLE
honister updates

### DIFF
--- a/honister.conf
+++ b/honister.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = honister
-last_revision = 4647e3ea3708d30eeb0149f6d5626c9576bff520
+last_revision = c05ae80ba680887ac924c21536091be7a1173427
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,5 +20,5 @@ last_revision = fb77606aef461910db4836bad94d75758cc2688c
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = honister
-last_revision = 883341e9ca18925b25e879866cca90bb57b552f2
+last_revision = e0ab08bb6a32916b457d221021e7f402ffa36b1a
 


### PR DESCRIPTION
poky 883341e9ca -> e0ab08bb6a:
    applied be73d9cb2530... pigz: fix one failure of command "unpigz -l"
    applied f33d89e0c20b... socat: update SRC_URI
    applied 1f56141337ea... linux-yocto/5.10: amdgpu: updates for CVE-2021-42327
    applied 430388334f72... linux-yocto/5.10: update to v5.10.91
    applied ea260558749d... bootchart2: Add missing python3-math dependency
    applied 5d0e1c73b78f... speex: fix CVE-2020-23903
    applied bf437d6a813c... expat: upgrade 2.4.1 -> 2.4.2
    applied acac13b4b8a8... expat: Upgrade 2.4.2 -> 2.4.3
    applied 94483d660778... vim: upgrade to 8.2 patch 3752
    applied b262b5cdf845... vim: update to include latest CVE fixes
    applied 9067e502b626... lighttpd: backport a fix for CVE-2022-22707
    applied cdcd59474cef... glibc : Fix CVE-2022-23218
    applied 4d7162798ec1... glibc : Fix CVE-2022-23219
    applied 6560edf43cc2... kernel: introduce python3-dtschema-wrapper
    applied 64a0161bdfb6... sstate: A third fix for for touching files inside pseudo
    applied eac9612ccdf0... insane.bbclass: Correct package_qa_check_empty_dirs()
    applied 023d0efb97b5... sstate: Improve failure to obtain archive message/handling
    applied a3f343f3f6c5... glibc : Fix CVE-2021-3998
    applied 4c0f19f62448... glibc : Fix CVE-2021-3999
    applied 2e790af6fb23... icu: fix make_icudata dependencies
    applied 96b1023aae63... tiff: backport fix for CVE-2022-22844
    applied e354c5716117... linux-yocto/5.10: update to v5.10.92
    applied 30b0bbe2113b... linux-yocto/5.10: update to v5.10.93
    applied 62a3149fef3a... linux-firmware: Add CLM blob to linux-firmware-bcm4373 package
    applied 7d52358534cf... yocto-check-layer: add debug output for the layers that were found
    applied 1c3f17f8d40c... libusb1: correct SRC_URI
    applied 908ba92d45c6... expat: upgrade to 2.4.4
    applied 1e15c2004589... vim: upgrade to patch 4269
    applied d7216047322a... core-image-sato-sdk: allocate more memory when in qemu
    applied 3873a51c58b7... libxml2: Backport python3-lxml workaround patch
    applied 3c5842ebfeab... poky.conf: bump version for 3.4.2 release
    applied e0ab08bb6a32... build-appliance-image: Update to honister head revision
meta-openembedded 4647e3ea37 -> c05ae80ba6:
    applied cf939ad69016... plymouth: switch to KillMode=mixed
    applied feab111e79ea... python3-prctl: Use https protocol for git fetcher
    applied 033fa7a408f9... dbus-daemon-proxy: add missing `return` statement
    applied a750888a40a7... snappy: use main branch to fix fetch failure
    applied ce24c81d847a... cmocka: use https protocol for fetching
    applied c05ae80ba680... tiptop: update download URL and HOMEPAGE

openbmc-subtree update -c honister.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
