### PR TITLE
subtree update: 499f724bd7 -> 1219fda1f8

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 9a52bfc4a646003088490de13e6500392ce01442
+last_revision = af11f6ce731707418676042034808954f108b2a0
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = c06ae5eacf3f822baf59aeedc4b2445096b209a7
+last_revision = 31c33d155c317ce70ae9b4a30a55e16a721f7177
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -20,5 +20,5 @@ last_revision = da93339112d0a53f0008a72dcacdb55dc3bf95a8
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 5fe3689f4f177eb918e1d8e1f5f1f3c5376aa073
+last_revision = 197652119006074f655704da113c57ab3f34e039
 


### PR DESCRIPTION
meta-openembedded 9a52bfc4a6 -> af11f6ce73:
    applied 7eace39caf91... mariadb: increase MY_AES_CTX_SIZE
    applied 8781a8fbcb7a... python3-evdev: fix host header contamination
    applied 957e8de43ea3... paho-mqtt-c: upgrade 1.3.9 -> 1.3.10
    applied ce604d453c9d... wxwidgets: 3.1.4 -> 3.1.5
    applied 6eb78d932f29... python3-wxgtk4: add recipe
    applied 78e31790e204... libopenmpt: Remove unnecessary python code block
    applied e75c865426bb... pipewire: Upgrade to version 0.3.49
    applied f3a7de2bdfa8... wireplumber: Upgrade to version 0.4.9
    applied f36fe239ad6e... python3-wxgtk4: Use cross prefix with native wx-config
    applied fe149bbb3689... strongswan: 5.9.4 -> 5.9.5
    applied 5b09a5ad78e9... nautilus: Add a packageconfig for libportal - disabled by default
    applied 0a2bd454d8a1... gtk4: upgrade 4.4.0 -> 4.6.2
    applied c7cb6b8d80d9... libadwaita: initial add 1.1.0
    applied db510a803c24... gtksourceview5: upgrade 5.2.0 -> 5.4.0
    applied 69c9070f9e91... libimobiledevice-glue: add recipe
    applied f42c97376693... libimobiledevice-glue: fix undefined bswap error
    applied 20c0c1874d0c... libirecovery: add recipe
    applied 02f2f6accbfd... idevicerestore: add recipe
    applied e0f5bcfc1d09... wxwidgets: fix typo
    applied 0caf66e939d5... libnetfilter-conntrack: upgrade 1.0.8 -> 1.0.9
    applied af11f6ce7317... mcelog: fix compile error
meta-raspberrypi c06ae5eacf -> 31c33d155c:
    applied b64df25754bc... linux-raspberrypi_5.15.bb: Upgrade to 5.15.32
    applied 03c6ab0cae20... raspberrypi-firmware: Update to match 5.15.32
    applied 31c33d155c31... armstubs: Upgrade to 20211101
poky 5fe3689f4f -> 1976521190:
    applied 1c4b8ba2ebc7... releases: update to include 3.4.3
    applied 28f244252037... set_versions/switchers: Drop versions shown to the active releases
    applied f4549231b28c... ref-manual: update Python class documentation
    applied c3b7982d2086... ref-manual: Remove references to AVAILABLE_LICENSES
    applied b60b432d2c9c... overview-manual: Fix reference
    applied e16ad94999e9... ref-manual: Add vfat in list of filesystems supported by kickstart
    applied 54b7b0561eaa... doc: migration-3.5: extend the section on inclusive language
    applied 01d846f21b84... overview-manual: add missing upper case
    applied ecab5f36555d... docs: add poky.yaml and sphinx-static/switchers.js to "make clean"
    applied 325c23cd0f80... manuals: fix quoting of double dashes
    applied a64ca37a138b... migration-guides: preliminary description for 3.5
    applied adb7ff6a260e... gobject-introspection: fix default search path for girdir
    applied 5b5a7567bcb1... convert-variable-renames: Fix typo in description
    applied 65c43b689442... mirrors: Add missing gitsm entries for yocto/oe mirrors
    applied 767a6fb13336... git: make expat and curl into PACKAGECONFIG items
    applied 90862733ed0d... weston: Add a knob to control simple clients
    applied ee5f9d9fdd7d... cmake: support to create per-toolchain cmake file in SDK
    applied 61c7c8f175d3... base: Don't add duplicates to sys.path
    applied e00f9ea165a2... base: Clean up module import compatibility code
    applied 21c3f0988033... modutils-initscripts: Change license PD -> MIT
    applied 7431f7766d2a... keymaps: Clean up license handling
    applied d677826f85b8... initscripts: Clean up license handling/identifiers
    applied 3087e2f2e6c3... buildtools-tarball: include nativesdk-python3-pyyaml
    applied c580bc6008f8... image_types: hddimg and iso only work on x86
    applied 13a1e484c3ea... oeqa/selftest/devtool: ensure Git username is set before upgrade tests
    applied 6cd1a31bef21... oeqa/selftest/wic: use os.rename instead of bb.utils.rename
    applied 8d01207fd764... oeqa/selftest/wic: remove redundant asserts
    applied e9c8d638f914... oeqa/selftest/wic: clean up only_for_arch decorator
    applied e2d112b4713e... oeqa/selftest/wic: don't hardcode kernel image type in test_wic_rm
    applied 1985249632d5... oeqa/selftest/wic: add more arch-specific annotations
    applied dd6987f49b25... oeqa/selftest/buildoptions: set PACKAGE_CLASSES in test_arch_work_dir_and_export_source
    applied b9df97f59c83... oeqa/runtime/decorator/package.py: remove use of strToSet
    applied ccc03581f5dd... oeqa/core/decorator: remove redundant code
    applied da6930c6f465... testimage: inline updateTestData()
    applied f4205dcf3d91... oeqa/core/utils/misc: remove redundant file
    applied 668753b8ed62... oeqa/selftest: remove unused imports
    applied 4e5f84902e52... oeqa/core/decorators/data: improve has_* logic
    applied 416cce968d3a... oeqa/selftest: tag tests that use runqemu
    applied fcc9c0ab37d1... oeqa: rationalise skipifqemu decorators
    applied 679917f98f08... oeqa/selftest/oescripts: refactor skipping logic
    applied 443d557ba0b1... oeqa/selftest/wic: cleanup WicTestCase.setUpLocal
    applied ada2cbb68290... oeqa/selftest/wic: rearrange tests
    applied 12a1456b060a... oeqa/selftest/wic: use os.path.join to join paths
    applied c4436040eb27... oeqa/selftest/wic: use self.td instead of get_bb_var to save on bitbake calls
    applied 9bcf56e6e7db... oeqa/selftest: generalise test_devtool_virtual_kernel_modify
    applied 2802ea07a836... python3: update to 3.10.4
    applied 3fdbeb0895a5... meson: Robustify compiler detection logic
    applied fd1a6bad77b0... bitbake: cooker: Further fixes to inotify to fix memres bitbake issues
    applied b731e47eeb3e... bitbake: cooker: Restore sys.path and sys.modules between parses
    applied 9b8eda7eb3f1... bitbake: cooker: Ensure any existing hashserv connection is closed
    applied 197652119006... bitbake: cooker: Avoid error if siggen wasn't setup

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
