### PR TITLE
subtree update: 76d114cab0 -> de0582f0e7

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,23 +2,23 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = af11f6ce731707418676042034808954f108b2a0
+last_revision = b9e440ead8908280041e87a5a8abe03718c808ad
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 31c33d155c317ce70ae9b4a30a55e16a721f7177
+last_revision = cfbb192e5ca303a5ca3731d9b1efce879dec873a
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = da93339112d0a53f0008a72dcacdb55dc3bf95a8
+last_revision = 498ca39cd69db8da0a03b30a865535d1ab047367
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 197652119006074f655704da113c57ab3f34e039
+last_revision = ed98f1a1ae7e4e2c8e089003a619ae9260a852ad
 


### PR DESCRIPTION
meta-raspberrypi 31c33d155c -> cfbb192e5c:
    applied 8d7e6b533b72... docs: untabify the few tabs in the file
    applied 1ea28cfb2a8d... docs: Add information for RTC devices
    applied 2beae018fbbe... rpi-cmdline: Add ability to specify CPUs to add to the isolcpus list
    applied 8eff5d59ed7f... extra-build-config: Add documentation for the ISOLATED_CPUS configuration variable
    applied 354e7153be0b... userland: Update to latest as of 20220323
    applied 9f5aaa1a2962... picamera-libs: Adjust sourcedir
    applied cfbb192e5ca3... omxplayer: Use internal version of ffmpeg
meta-openembedded af11f6ce73 -> b9e440ead8:
    applied 88602b17c8ab... python3-cheetah: upgrade 3.2.6.post2 -> 3.2.6
    applied 9ed8af2ff60f... python3-evdev: upgrade 1.4.0 -> 1.5.0
    applied 56f4d9d6f32a... python3-google-api-python-client: upgrade 2.36.0 -> 2.42.0
    applied bbc35b7cabb8... python3-itsdangerous: upgrade 2.1.1 -> 2.1.2
    applied dcd071e3d945... python3-grpcio: upgrade 1.44.0 -> 1.45.0
    applied ff91dcb8657f... python3-jdatetime: upgrade 4.0.0 -> 4.1.0
    applied 173352732d17... python3-kiwisolver: upgrade 1.4.0 -> 1.4.2
    applied b1645981ffd9... python3-wxgtk4: add distro feature check to match dependency
    applied 667c8e52da6a... python3-bitarray: upgrade 2.4.0 -> 2.4.1
    applied 048db8d5e221... python3-click: upgrade 8.0.4 -> 8.1.2
    applied c4c2a90040bf... python3-cppy: upgrade 1.2.0 -> 1.2.1
    applied 15f39bff0feb... python3-pandas: upgrade 1.4.1 -> 1.4.2
    applied 9e20c76207ee... python3-protobuf: upgrade 3.19.4 -> 3.20.0
    applied 166cfe0ae2aa... python3-pychromecast: upgrade 10.3.0 -> 11.0.0
    applied db5534e53166... python3-pyparted: upgrade 3.11.7 -> 3.12.0
    applied 693b48eea500... python3-redis: upgrade 4.2.0 -> 4.2.1
    applied 6e5e78935b1c... python3-sqlalchemy: upgrade 1.4.32 -> 1.4.34
    applied 7ed0c087c420... python3-thrift: upgrade 0.15.0 -> 0.16.0
    applied e0e359d6320c... python3-trafaret: upgrade 2.1.0 -> 2.1.1
    applied 6897a20aeac5... python3-twine: upgrade 3.8.0 -> 4.0.0
    applied 241970c5dbaa... python3-tzlocal: upgrade 4.1 -> 4.2
    applied 868aac218874... python3-websocket-client: upgrade 1.3.1 -> 1.3.2
    applied d1896eee1eee... python3-werkzeug: upgrade 2.0.3 -> 2.1.1
    applied f00ec3db13a4... python3-qface: upgrade 2.0.6 -> 2.0.7
    applied fcdafe933c96... dracut: upgrade 055 -> 056
    applied ebcf4c75f00c... octave: upgrade 4.4.1 -> 6.4.0 and overhaul recipe
    applied 7b6121ac1cca... mousepad: upgrade 0.5.8 -> 0.5.9
    applied b8a37b163ac2... xfce4-terminal: upgrade 0.8.10 -> 1.0.0
    applied 6d16352de522... orage: upgrade 4.12.1 -> 4.16.0
    applied dc0c7b0e3a83... orage: enable notify PACKAGECONFIG by default
    applied bcad5e3936cf... ristretto: upgrade 0.12.1 -> 0.12.2
    applied a6cc207cbc12... xarchiver: upgrade 0.5.4.14 -> 0.5.4.17
    applied 29b2dc285611... xfce4-cpufreq-plugin: upgrade 1.2.5 -> 1.2.7
    applied cad228065a95... xfce4-cpugraph-plugin: upgrade 1.2.5 -> 1.2.6
    applied c1fd58848633... xfce4-diskperf-plugin: upgrade 2.6.3 -> 2.7.0
    applied 53c094eb600a... xfce4-notifyd: upgrade 0.6.2 -> 0.6.3
    applied c160fcbede68... xfce4-screenshooter: upgrade 1.9.9 -> 1.9.10
    applied 9f26743034ac... xfce4-sensors-plugin: upgrade 1.4.2 -> 1.4.3
    applied b304441d3645... Allow several components notification
    applied 722a929cca8c... meta-xfce: Add Andreas Müller back to maintainers list
    applied 28006d9af112... xfce4-screenshooter: Add dependency on libxml-parser-perl-native
    applied 6c422afeea81... wxwidgets: Fix checking for PACKAGECONFIG and DISTRO_FEATURES
    applied 929ae5a43404... wxwidgets: git -> gitsm to fix build when no x11
    applied ec0eac55ff61... blueman: fix python site-packages installation issue
    applied 9e215a8b657d... open-vm-tools: Use specific BSD-2-Clause for license
    applied 3b64d027cf6e... srt: 1.4.2 -> 1.4.3
    applied 3497386ae49a... srt: 1.4.3 -> 1.4.4
    applied 8eb7e5c1d050... accountsservice: upgrade 0.6.55 -> 22.08.8
    applied 4f3ac298f0c8... colord-gtk: upgrade 0.2.0 -> 0.3.0
    applied 4c5a630e7f46... evince: upgrade 41.4 -> 42.1
    applied 52d5054fc062... evolution-data-server: upgrade 3.43.1 -> 3.44.0
    applied 7a49c6ec8e3d... file-roller: upgrade 3.40.0 -> 3.42.0
    applied 6efe7fc0fe0c... gdm: upgrade 41.0 -> 42.0
    applied 4d847e7da989... gedit: upgrade 41.0 -> 42.0
    applied 8e7bae430033... gfbgraph: upgrade 0.2.4 -> 0.2.5
    applied b7dd1933afd3... gnome-calculator upgrade 41.1 -> 42-0
    applied 8a90160e07bf... libgweather4: initial add 4.0.0
    applied c495d52501ec... gnome-calendar 41.2 -> 42.0
    applied 9b7cce886087... gnome-desktop: upgrade 41.2 -> 42.0
    applied a158572927d6... libnma: upgrade 1.8.34 -> 1.8.36
    applied 18c6ce122496... gnome-bluetooth4: initial add 42.0
    applied 5bcfcc078c6a... gnome-font-viewer: upgrade 41.0 -> 42.0
    applied 7c46176f44c6... yelp-xsl: upgrade 41.1 -> 42.0
    applied b0d003a8f5f5... yelp-tools: upgrade 41.0 -> 42.0
    applied bea1dbb3f7c4... yelp: upgrade 41.2 -> 42.1
    applied bcb6af4c10d4... fwupd: add COMPATIBLE_HOST to match dependency
    applied 8253fe2a9cd6... upower: upgrade 0.99.13 -> 0.99.17 / build with mesom
    applied 98caf54fa575... upower: fix location of udev-rules with sysvinit
    applied e88927d122c1... gnome-commander: initial add 1.14.2
    applied b9b9da006480... gnome-text-editor: initial add 42.0
    applied b37a5df692cf... zenity: upgrade 3.41.0 -> 3.42.0
    applied 2a1400c8e2ea... ceres-solver: upgrade 2.0.0 -> 2.1.0
    applied 4c50d31a567c... grpc: upgrade 1.45.0 -> 1.45.1
    applied 07c00ecba6fe... poppler: upgrade 22.03.0 -> 22.04.0
    applied 9609a9046fb8... xorg-sgml-doctools: upgrade 1.11 -> 1.12
    applied 4c14cc3dc203... evolution-data-server: re-enable gobject-introspection
    applied 423a01e9ef6b... jack: upgrade 1.19.19 -> 1.19.20
    applied a164804d76e8... fluidsynth: upgrade 2.2.4 -> 2.2.6
    applied dd5ed4dcbb2a... samba: add 2 cves to allowlist
    applied 85460656d934... libzip: add CVE-2017-12858 to allowlist
    applied e1de27d8011f... multipath-tools: update SRC_URI
    applied 6e6f6fd6523b... dnsmasq: Fix a typo in initscript
    applied 41b44264e36c... libimobiledevice-glue: update recipe
    applied b9e440ead890... srecord: build fix
meta-security da93339112 -> 498ca39cd6:
    applied 943f48419a21... openscap-daemon: use renamaed python_setuptools_build_meta
    applied c56ae450c93a... meta-security : Use SPDX style licensing format
    applied 0c41d792cf83... LICENSE: adopt SPDX standard names
    applied 2be1d069ec4b... python3-fail2ban: fix compile issue on some hosts
    applied fb6704224286... lkrg-module: covert to git fetcher
    applied cfb79c913f88... linux-yocto_security.inc: add lkrg kfrags
    applied 48d6ff13e37c... samhain: update to 4.4.7
    applied e92fad507a47... clamav: add COMPATIBLE_HOST to fix build error
    applied 498ca39cd69d... fscrypt: update dependecy from go-dep-native to go-native
poky 1976521190 -> ed98f1a1ae:
    applied d0a05c2cf9a4... busybox: Exclude .debug from depmod
    applied 708cbdf3c9d9... kmod: Add an exclude directive to depmod
    applied 2a02a178af98... depmodwrapper: Use nonarch_base_libdir for depmod.d
    applied 1459f495ba40... glib-2.0: Backport patches C++ variant of g_atomic_int_compare_and_exchange()
    applied 7e8d8b0dca0e... python3-jinja2: Correct HOMEPAGE
    applied ffbf7d2b97ff... popt: add ptest
    applied fb1291ea5f6f... kernel.bbclass: Use KERNEL_IMAGEDEST instead of hardcoded boot path
    applied 99bcad583aee... gcc: sanitizer: Fix tsan against glibc 2.34
    applied b868387c425c... bitbake: parse: Ensure any existing siggen is closed down first
    applied 70d636060276... bitbake: data: Ensure vardepsexclude or BB_BASEHASH_IGNORE_VARS covers contains items
    applied 496cbc01ca0f... bitbake: server/process: Disable gc around critical section
    applied d0082265d535... bitbake: cooker: Reset and rebuild inotify watches
    applied dfc910bdc246... bitbake: pyinotify: Handle potential latent bug
    applied 61d38cd3a290... mirrors: Switch glibc and binutils to use shallow mirror tarballs
    applied 8c9503880e7d... insane.bbclass: Make do_qa_patch() depend on if patch-fuzz is in ERROR_QA
    applied decda506b361... insane.bbclass: Make changes to QA_EMPTY_DIRS trigger package_qa to rerun
    applied 67cbfc8494b4... bitbake.conf: Remove ERROR_QA from BB_HASHEXCLUDE_COMMON
    applied 9646dae4b293... tzdata: update to 2022a
    applied 939142ff9cf7... waffle: The surfaceless-egl and gbm requires opengl
    applied 6b2ca964347c... bitbake: data: Fix accidentally added parameter
    applied 6459a06f2ed7... unzip: fix CVE-2021-4217
    applied 4b15ff6efb6d... bitbake.conf: Drop unexports from a different era
    applied ca405e4529db... vim: Upgrade 8.2.4524 -> 8.2.4681
    applied daafcdfb16a7... kmod: Update exclude patch to Accepted
    applied 56104084022d... linux-yocto/5.15: update to v5.15.32
    applied ade78510bde3... linux-yocto/5.10: update to v5.10.109
    applied 7d45877e26e8... linux-yocto/5.15: aufs: fixes and optimization
    applied 3a2b9dfa75c2... linux-yocto-rt/5.15: aufs: compile fix
    applied 5979a3928faa... linux-yocto/5.15: features/security: Move x86_64 configs to separate file
    applied fd22b5e48862... linux-yocto/5.10: features/security: Move x86_64 configs to separate file
    applied e4c16d11128f... meta: rust: Bug fix for target definitions returning 'NoneType'
    applied 12b4074675bc... bitbake: knotty.py: Show elapsed time also for tasks with progress bars
    applied 0bf2fd162734... Revert "meta: rust: Bug fix for target definitions returning 'NoneType'"
    applied a2b9eea5b0cd... depmodwrapper-cross: Fix missing $
    applied 4a77431efcff... pseudo: Fix handling of absolute links
    applied 498f9c58c885... os-release: add os-release-initrd package
    applied 601befb6c768... meta: scripts - relocation script adapted to support big-endian machines
    applied 13eda43533f0... oe-init-build-env: add quotes around variables to prevent word splitting
    applied 91d6c0346487... u-boot: Fix condition for install_spl_helper
    applied ee994c89b6... libsdl2: Disable libunwind dependency in native builds
    applied bd8f1f7787... gpg-sign: Add parameters to gpg signature function
    applied 0b4231b597... package_manager: sign DEB package feeds
    applied ed98f1a1ae... build-appliance-image: Update to master head revision

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
