### PR TITLE
subtree update: d8d011f286 -> c6a9728fdb

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = b9e440ead8908280041e87a5a8abe03718c808ad
+last_revision = 1888971b1fcff1e86be175c2aac724c28d2840ca
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = cfbb192e5ca303a5ca3731d9b1efce879dec873a
+last_revision = 83f5577d8d8a5383642cd00a75ec56211596ecd2
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -20,5 +20,5 @@ last_revision = 498ca39cd69db8da0a03b30a865535d1ab047367
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = ed98f1a1ae7e4e2c8e089003a619ae9260a852ad
+last_revision = 30b38d9cb9262e1171746d4b538022b9ff86c307
 


### PR DESCRIPTION
meta-raspberrypi cfbb192e5c -> 83f5577d8d:
    applied 83f5577d8d8... linux-raspberrypi: add UBOOT_ENTRYPOINT to match LOADADDR
poky ed98f1a1ae -> 30b38d9cb9:
    applied 89efab28507... connman-conf: ignore eth0 in qemu in a way that is not sysvinit-specific
    applied 30eb28dd029... xz: fix CVE-2022-1271
    applied 55bed213cff... gzip: upgrade 1.11 -> 1.12
    applied 3d4e5a0b7fd... uninative: Upgrade to 3.6 with gcc 12 support
    applied 21f0318abc5... package_ipk/deb: Fix specific version handling
    applied 8b4a6546417... python3-cryptography: backport fix for leaky test
    applied d281f682737... spirv-tools: fix to use sdk-1.3.204 branch
    applied 632c83ab787... license_image.bbclass: close package.manifest file
    applied b2fb36feadd... libarchive: Upgrade to 3.6.1
    applied d429e927d8c... kernel.bbclass: Fix the do_strip() malfunction
    applied 30b38d9cb92... musl: Move to 1.2.3 release tag
meta-openembedded b9e440ead8 -> 1888971b1f:
    applied bb6a70a4638... ot-br-posix: add recipe for an OpenThread Border Router
    applied 47640c2235e... ot-daemon: add recipe for OpenThread daemon
    applied b75d3b24618... wpantund: add new recipe
    applied bbbd86d87e7... MAINTAINERS: add entry for OpenThread
    applied 8e55b9aef88... wxwidgets: fix wx-config multilib issue
    applied d8187782ca6... libyang: do not inherit binconfig-disabled
    applied 8291505ccdc... ndctl: fix build failure with EXEWRAPPER_ENABLED False
    applied 1a91a9cb278... grpc: add cmake support for target
    applied b04696ddf8d... grpc: remove useless link with libatomic append
    applied 5e5d973d781... wxwidgets: Fix building without x11
    applied 6305aacfded... Revert "python3-cppy: upgrade 1.2.0 -> 1.2.1"
    applied ae60e9869b3... drbd-utils: update 9.13.1 -> 9.20.2
    applied 085bfd3601a... libotr: Include missing sys/socket.h header
    applied a3dab74a890... grpc: remove unused patches
    applied 668ed5c5c9b... libcereal: Link in libatomic on rv32 for ptests
    applied 150581b6373... gnuplot: Disable libcerf and fix typo
    applied 8d3ee7b2d83... gparted: update to v1.4.0
    applied 35ea4b37bae... libcereal: Disable on ppc/ppc64
    applied b924bc52ca6... python3-wxgtk4: pass '--baselib' to WX_CONFIG
    applied 46612115db6... python3-wxgtk4: Require DISTRO_FEATURES as gtk3
    applied 7177c2ec0f0... python3-beautifulsoup: update to 4.11.1
    applied 2f55a5ee2ff... python3-bidict: update to 0.22.0
    applied 8bfdee2f781... python3-can: update t 4.0.0
    applied a8589dd218f... python3-elementpath: update to 2.5.0
    applied 50378fee900... python3-flask-login: update to 0.6.0
    applied db1c8cea6a9... python3-flask: update to 2.1.1
    applied e43b914f4ff... python3-gcovr: update to 5.1
    applied 48ac68e512e... python3-google-api-core: update to 2.7.1
    applied cf279b1fe67... python3-google-auth: update to 2.6.3
    applied 9827b0faf83... python3-grpcio-tools: update to 1.45.0
    applied bd3643a5c38... python3-ipython: update to 8.2.0
    applied 09c9b9b0046... python3-jmespath: update to 1.0.0
    applied 2b62902692d... python3-mypy: update to 0.942
    applied c2d40891000... python3-pint: update to 0.19.1
    applied 696a6996be1... python3-portalocker: update to 2.4.0
    applied 30a91174120... python3-pulsectl: update to 22.3.2
    applied 2d24d2964c8... python3-pycurl: update to 7.45.1
    applied f42937f461f... python3-pymogo: update to 4.1.0
    applied 5d72100f746... python3-pyscaffold: update to 4.2.1
    applied 82f1f3d1653... python3-pytest-helpers-namespace: update to 2021.12.29
    applied 6842d6ae21d... python3-pywbem: update to 1.4.1
    applied 917127aec5b... python3-regex: update to 2022.3.15
    applied 4158bd57dbe... python3-sympy: update to 1.10.1
    applied 22ce644f15b... python3-tqdm: update to 4.64.1
    applied c7b81b90380... python3-twitter: update to 4.8.0
    applied 079f04dbb2b... python3-xmlschema: update to 1.10.0
    applied 22fa5222612... python3-zeroconf: update to 0.38.4
    applied cf80085c065... googletests: Update SRC_URI to 9e71237 to move closer to lastest version
    applied 2347b70a368... octave: add PACKAGECONFIG for (Qt-)gui - disabled by default
    applied 231ba4627dd... xfce4-eyes-plugin: upgrade 4.5.1 -> 4.6.0
    applied 3cd40ec9403... gnome-online-accounts: upgrade 3.43.1 -> 3.44.0
    applied 10726b25575... mutter: upgrade 41.2 -> 42.0
    applied b74602b4073... gnome-shell: upgrade 41.2 -> 42.0
    applied 3d3a31f6da1... haveged: upgrade 1.9.17 -> 1.9.18
    applied 7463469d4e2... hidapi: upgrade 0.10.1 -> 0.11.2
    applied 6b25556d2f3... hwdata: upgrade 0.357 -> 0.358
    applied 3698e333b18... evolution-data-server: Disable g-i on musl
    applied 01104d4ef10... broadcom-bt-firmware: upgrade 12.0.1.1105_p2 -> 12.0.1.1105_p3
    applied 3427ee3bb1d... byacc: upgrade 20211224 -> 20220128
    applied aebd911ce1f... ctags: upgrade 5.9.20211114.0 -> 5.9.20220410.0
    applied e03ef400f02... feh: upgrade 3.6.1 -> 3.8
    applied 31e0ca154cb... fio: upgrade 3.29 -> 3.30
    applied 1888971b1fc... grpc: upgrade 1.45.1 -> 1.45.2

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
