### PR TITLE
subtree update: e093d3473a -> ab475af389

### DIFF
--- a/dunfell.conf
+++ b/dunfell.conf
@@ -92,7 +92,7 @@ last_revision = 168440a0f1c89fc8ef6cabea033c5611d323df89
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = dunfell
-last_revision = ab9fca485e13f6f2f9761e1d2810f87c2e4f060a
+last_revision = fdd1dfe6b4b2412cc536c26450ce126c960d8107
 
 [meta-openpower]
 src_uri = https://gerrit.openbmc-project.xyz/openbmc/meta-openpower
@@ -134,7 +134,7 @@ last_revision = 934064a01903b2ba9a82be93b3f0efdb4543a0e8
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = dunfell
-last_revision = b76698c788cb8ca632077a972031899ef15025d6
+last_revision = c62970fda82acf75035243766ecd195243e0f82a
 
 [meta-x86]
 src_uri = https://gerrit.openbmc-project.xyz/openbmc/meta-x86
@@ -158,5 +158,5 @@ last_revision = 7eef85ee0d2e6f8100c06c0f9a9cb52c941ecd50
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = dunfell
-last_revision = bba323389749ec3e306509f8fb12649f031be152
+last_revision = b6ce93d565cec4eca94da05f3b9bf7f6bf115b75
 


### PR DESCRIPTION
meta-openembedded ab9fca485e -> fdd1dfe6b4:
    applied 4735d66eae0... apache2: upgrade 2.4.51 -> 2.4.52
    applied cc9e6dabcbe... netcat: Set CVE_PRODUCT
    applied 9e5b6ad6cec... strongswan: Fix for CVE-2021-41990 and CVE-2021-41991
    applied cc90900dfb3... wireshark: Update to 3.2.18
    applied 4bd7715a9dc... c-ares: bump PV in recipe to 1.16.1
    applied 46a2333262d... CVE-2021-4034: polkit Local privilege escalation in pkexec due to incorrect handling of argument vector
    applied 2a10c182ae6... dbus-daemon-proxy: add missing `return` statement
    applied 4e7d34df0fc... udisks2: Fix for CVE-2021-3802
    applied 9d722e88d79... p7zip: fix for CVE-2018-5996
    applied 872e60a774b... linuxptp: Update to 2.0.1
    applied ec978232732... nodejs: Fix for CVE-2021-44532
    applied 93a315f96f9... strongswan: Add fix of CVE-2021-45079
    applied aa5b9a1ff04... nss: Add fix for CVE-2022-22747
    applied 7c519caa1a6... graphviz: native: create /usr/lib/graphviz/config6 in populate_sysroot
    applied a6c1c340311... cryptsetup: Add runtime dependency on lvm2-udevrules for udev
    applied 0722ff6f021... protobuf: Fix CVE-2021-22570
    applied 67ec3e04924... polkit: Fix for CVE-2021-4115
    applied 9aaa0318934... pw-am.sh: update to new patcwork system
    applied a09ddd737e9... tcpreplay: Add fix for CVE-2020-24265 and CVE-2020-24266
    applied a14eb5e288a... protobuf: fix patch fuzz
    applied 29e3a918ac8... googletest: Switch branch from master to main
    applied 7334bc295d6... p7zip: build and package lib7z.so needed for fastboot
    applied e6a4c8e5c54... p7zip: refresh patches
    applied 0940e1e3827... nginx: backport fix for CVE-2019-20372
    applied 17e931e7762... polkit: fix CVE-2021-3560
    applied 4f701b46551... p7zip: Fix for CVE-2016-9296
    applied 86b864a4d8c... openjpeg: Fix multiple CVE
    applied 17ee7b03482... imagemagick: update SRC_URI branch from master to main
    skipped 717b8b92867... cli11: switch from default master branch to main to fix do_fetch failure
    applied ac85c97636d... breakpad: fix branch for gtest in SRC_URI
    applied bd08205d945... breakpad: Update SRC_URI for protobuf and lss
    applied 7abb2382cd2... spirv-tools: update SRC_URI for googletest to main
    applied 89d2876e2e6... nodejs: upgrade to 12.22.2
    applied 388dc2830af... geoip: Switch to use the main branch
    applied 5cdde2991e7... multipath-tools: update SRC_URI
    applied aa316ee2bbf... polkit: fix overlapping changes in recent CVE patches
    applied dbf01a10e27... python3-urllib3: Fix CVE-2020-26137 and CVE-2021-33503
    applied 8314be774a6... apache2: upgrade 2.4.52 -> 2.4.53
    applied df8259cc49b... Mariadb: update to 10.4.24
    applied fdd1dfe6b4b... mongodb: Pass OBJCOPY to scons so it does not use it from host
meta-security b76698c788 -> c62970fda8:
    applied 5467910ed76... sssd: re-package to fix QA issues
    applied dc2c75e9813... tpm2-tools: backport fix for CVE-2021-3565
    applied e95a877981f... tpm2-tools: update to 4.1.3
    applied 95a8f38d2e3... clamav: disable DB creation.
    applied 6982841ed91... clamav: drop creating cvd package
    applied c62970fda82... chkrootkit: update SRC_URI
poky bba3233897 -> b6ce93d565:
    applied bbd2561fe9a... glibc: update to lastest 2.31 release HEAD
    applied 40d6918639c... systemd: Fix CVE-2021-3997
    applied f5fe6f2a64e... grub: add a fix for CVE-2020-25632
    applied 9959bee1af8... grub: add a fix for CVE-2020-25647
    applied b03d18892cd... ghostscript: fix CVE-2021-45949
    applied 5eab654048d... expat: fix CVE-2022-23852
    applied 239fa60002a... expat: add missing Upstream-status, CVE tag and sign-off to CVE-2021-46143.patch
    applied 169e03b9b37... util-linux: Fix for CVE-2021-3995 and CVE-2021-3996
    applied 4cd2d8de2a1... binutils: Backport Include members in the variable table used when resolving DW_AT_specification tags.
    applied 094a3ba047e... sstate: A third fix for for touching files inside pseudo
    applied 2a4cdd5ff59... common-licenses: add Spencer-94
    applied ea8e0dd0720... lsof: correct LICENSE
    applied 76a93e4ac97... tzdata: Remove BSD License specifier
    applied 055b8c20938... e2fsprogs: Use specific BSD license variant
    applied fb2d910ef74... glib-2.0: Use specific BSD license variant
    applied 7cee8440c41... shadow: Use specific BSD license variant
    applied 762912b1b5c... shadow-sysroot: sync license with shadow
    applied e92b9b6bf66... libcap: Use specific BSD license variant
    applied e340dafa0e6... linux-firmware: Add CLM blob to linux-firmware-bcm4373 package
    applied fca7b22674a... libusb1: correct SRC_URI
    applied 7f93b8dff57... releases: update to include 3.1.14
    applied 3d5dd4dd8d6... documentation: update for 3.1.14 release
    applied 68361809978... bitbake: tests/fetch: Handle upstream master -> main branch change
    applied 08ecf46de00... expat: fix CVE-2022-23990
    applied 17023dee9ba... connman: fix CVE-2022-23096-7
    applied 9c8b4200967... connman: fix CVE-2022-23098
    applied 0c48142849d... connman: fix CVE-2021-33833
    applied 19d3dc1ebb7... wpa-supplicant: fix CVE-2022-23303-4
    applied ea8e23b4826... lighttpd: backport a fix for CVE-2022-22707
    applied d9a33413949... binutils: Fix CVE-2021-45078
    applied 4d679f1e079... freetype: add missing CVE tag CVE-2020-15999
    applied 599987e9845... cve-check: create directory of CVE_CHECK_MANIFEST before copy
    applied 97586f5d623... recipetool: Fix circular reference in SRC_URI
    applied e3f9b3a4975... devtool: deploy-target: Remove stripped binaries in pseudo context
    applied 7b27c85ed93... rpm: fix intermittent compression failure in do_package_write_rpm
    applied 8d3efda87dc... cmake: remove bogus CMAKE_LDFLAGS_FLAGS definition from toolchain file
    applied fedd12ae6db... linux-yocto/5.4: update to v5.4.173
    applied 32bf0d1e480... linux-yocto/5.4: update to v5.4.176
    applied 6ea06ed9f0a... linux-yocto/5.4: update to v5.4.178
    applied a4501bdd1a1... linux-firmware: upgrade 20211216 -> 20220209
    applied b34672df173... sdk: fix search for dynamic loader
    applied 2a96d2a9326... default-distrovars.inc: Switch connectivity check to a yoctoproject.org page
    applied 6060b500b95... ruby: correctly set native/target dependencies
    applied f58e88f4d85... ruby: fix DEPENDS append
    applied c6b1d0eac14... Revert "vim: fix CVE-2021-4069"
    applied 7c237d3b2d4... vim: set PACKAGECONFIG idiomatically
    applied dffd5c120b8... vim: upgrade to 8.2 patch 3752
    applied 4359fb29f96... vim: do not report upstream version check as broken
    applied 3bb6c52e22d... vim: update to include latest CVE fixes
    applied acc692cfec6... vim: upgrade to patch 4269
    applied febd9f67151... vim: Upgrade 4269 -> 4134
    applied c8987e7bca6... vim: Upgrade 8.2.4314 -> 8.2.4424
    applied bb6b6f5a557... openssl: Add fix for CVE-2021-4160
    applied df471272aee... tiff: fix for CVE-2022-22844
    applied 940fcf35b2c... ruby: 2.7.4 -> 2.7.5
    applied ac746716fc5... puzzles: Upstream changed to main branch for development
    applied 01eb48b7f56... grub: fix a memory leak
    applied 6b514d38b7f... grub: add a fix for a possible NULL dereference
    applied 058d20254f2... grub: fix a dangling memory pointer
    applied ee33ef82427... grub: fix wrong handling of argc == 0
    applied 763007dff13... grub: add a fix for malformed device path handling
    applied 4a5a4dbcf61... grub: fix memory leak at error in grub_efi_get_filename()
    applied c4ca12868c2... grub: add a fix for a possible NULL pointer dereference
    applied db637b05554... grub: add a fix for unused variable in gnulib
    applied e1122f6dade... grub: fix an unitialized token in gnulib
    applied ab977b3f498... grub: add a fix a NULL pointer dereference in gnulib
    applied ba476f819f8... grub: add a fix for NULL pointer dereference
    applied 877ea55a5bf... grub: fix an unitialized re_token in gnulib
    applied 37f35c47827... grub: add a fix for unnecessary assignements
    applied 495bf963be2... grub: add structure initialization in zstd
    applied 90b1d407c66... grub: add a missing NULL check
    applied da4ba2d04e3... grub: fix a memory leak
    applied b854e27c584... grub: fix a memory leak
    applied 40d7b770308... grub: fix a memory leak
    applied e97cfd16602... grub: fix an integer overflow
    applied 3348511b945... grub: add a fix for a length check
    applied b461e690255... grub: add a fix for a possible negative shift
    applied 0dd3f436f47... grub: add a fix for a memory leak
    applied f4c3f4508a6... grub: add a fix for possible integer overflows
    applied 1246e75875a... grub: fix an error check
    applied 10d619c8bb8... grub: add a fix for a memory leak
    applied e2f193d2521... grub: add a fix for a possible unintended sign extension
    applied b46710743b3... grub: add a fix for a possible NULL dereference
    applied 4c7bfa8abe0... grub: add a fix for a memory leak
    applied bd3bda5d035... grub: add a fix for a memory leak
    applied acec862ed28... grub: fix a memory leak
    applied b5eaa833ba0... grub: remove unneeded return value
    applied 7e7b8e38dc0... grub: fix an integer overflow
    applied 628257a582d... grub: fix multiple integer overflows
    applied eca24c02eac... grub: fix a possible integer overflow
    applied 4463703292a... grub: test for malformed jpeg files
    applied f82639b50e3... grub: remove dead code
    applied dfae6953432... grub: fix checking for NULL
    applied a558b15d7f5... grub: add a fix for a memory leak
    applied 11b10eac41c... grub: avoid a memory leak
    applied d65bf404bc8... grub: add a check for a NULL pointer
    applied 1a338ab4664... grub: add a fix for NULL pointer dereference
    applied 6360727bb14... grub: add a fix for an incorrect cast
    applied 9b69e691603... grub: fix incorrect use of a negative value
    applied 8d050d1e45a... grub: add a fix for a NULL pointer dereference
    applied 7fae28df197... grub: avoid a NULL pointer dereference
    applied 9426c3c83d2... grub: add a fix for a crash in scripts
    applied 6bba192936c... libarchive: Fix for CVE-2021-36976
    applied dfd900b5b0a... go: fix CVE-2022-23806
    applied 415757639d8... go: fix CVE-2022-23772
    applied e8fef0c8cfe... expat: fix CVE-2022-25235
    applied 746111afa00... expat: fix CVE-2022-25236
    applied e173db21d08... expat: fix CVE-2022-25313
    applied 32db22beecc... expat: fix CVE-2022-25314
    applied 81a3da3b990... expat: fix CVE-2022-25315
    applied 18161d9e478... coreutils: remove obsolete ignored CVE list
    applied 99bb7a2d308... cve-check: get_cve_info should open the database read-only
    applied 2658fb04ac2... Revert "cve-check: add lockfile to task"
    applied d6d65d76855... wireless-regdb: upgrade 2021.08.28 -> 2022.02.18
    applied 820be4beeb7... bootchart2: Add missing python3-math dependency
    applied 4c7c64cc6eb... cml1.bbclass: Handle ncurses-native being available via pkg-config
    applied fcd27727c1d... libxml-parser-perl: Add missing RDEPENDS
    applied 13aefbd92d3... buildhistory.bbclass: create the buildhistory directory when needed
    applied 3cb3cee660c... uninative: Add version to uninative tarball name
    applied 94b275e15e9... uninative: Upgrade to 3.5
    applied 76fa5fae9e1... ref-system-requirements.rst: update list of supported distros
    applied 9b9fd2b0954... docs: fix hardcoded link warning messages
    applied f07bd53e6a1... linux-yocto: update genericx86* to v5.4.178
    applied 8ddcfbfe019... poky.conf: update tested distros
    applied b9917c90a20... poky.conf: Bump version for 3.1.15 release
    applied 3b70636be4f... asciidoc: update git repository
    applied 11fba270e74... systemd: Ensure uid/gid ranges are set deterministically
    applied e4cc9273f5f... sstate: inside the threadedpool don't write to the shared localdata
    applied f3baa35d428... vim: Update to 8.2.4524 for further CVE fixes
    applied ce4a1354ccf... tiff: Add backports for two CVEs from upstream
    applied f593e21aad8... perf-tests: add bash into RDEPENDS (v5.12-rc5+)
    applied b41d4e46d30... bind: update to 9.11.36
    applied 52b59e88411... build-appliance-image: Update to dunfell head revision
    applied 3ec873af83c... documentation: update for 3.1.15 release
    applied 0c0b8487c96... libxml2: backport fix for CVE-2022-23308
    applied cb78d34faf3... libxml2: move to gitlab.gnome.org
    applied 9d155cbf956... re2c: backport fix for CVE-2018-21232
    applied 094a9a9a236... qemu: backport fix for CVE-2020-13253
    applied 8b369ca021c... bluez5: fix CVE-2021-3658
    applied 95bdd2e6f83... openssl: upgrade 1.1.1l -> 1.1.1n
    applied c625f6524db... python3: upgrade 3.8.12 -> 3.8.13
    applied c1f606809d9... linux-firmware: upgrade 20220209 -> 20220310
    applied c740a0b5a3f... mobile-broadband-provider-info: upgrade 20201225 -> 20210805
    applied 08b8cd174d8... mobile-broadband-provider-info: upgrade 20210805 -> 20220315
    applied 4c3d1b0120c... python3targetconfig: Use for nativesdk too
    applied 22be09c7088... oeqa/runtime/ping: Improve failure message to include more detail
    applied 8183149d3e0... oeqa/selftest/tinfoil: Improve tinfoil event test debugging
    applied 7616c493557... bitbake: server/process: Note when commands complete in logs
    applied 8b09f50d1ab... bitbake: tinfoil: Allow run_command not to wait on events
    applied d084cd43889... poky: Drop PREMIRRORS entries for scms
    applied e779ccdf4e7... libsolv: fix CVE: CVE-2021-44568-71 and CVE-2021-44573-77
    applied 513cfaa43df... python3: ignore CVE-2022-26488
    applied d69c49f33a8... qemu: backport patch fix for CVE-2020-13791
    applied 92b8b18ca9c... apt: backport patch fix for CVE-2020-3810
    applied 4391ddecb2c... ghostscript: fix CVE-2020-15900 and CVE-2021-45949 for -native
    applied a27aa2316f3... ghostscript: backport patch fix for CVE-2021-3781
    applied 82abf31270b... libxml2: fix CVE-2022-23308 regression
    applied b6e2a1acd42... gnu-config: update SRC_URI
    applied 5a05390de12... virglrenderer: update SRC_URI
    applied 631df129692... oeqa/selftest/tinfoil: Fix intermittent event loss issue in test
    applied 67f1490197b... util-linux: fix CVE-2022-0563
    applied 14127d25e79... xserver-xorg: update to 1.20.9
    applied e2ecbb13db5... xserver-xorg: update to 1.20.10
    applied 884024d1d86... xserver-xorg: update to 1.20.11
    applied a5f13b762b3... xserver-xorg: update to 1.20.12
    applied f0240a36a39... xserver-xorg: update to 1.20.13
    applied a743227d813... xserver-xorg: update to 1.20.14
    applied ab03f130e44... bitbake: fetch2: add check for empty SRC_URI hash string
    applied f80b5868fa1... grub: ignore CVE-2021-46705
    applied 048094bcf91... go: backport patch fix for CVE-2021-38297
    applied 64205bf3ec0... bluez5: fix CVE-2022-0204
    applied 7e0d217559d... bind: update to 9.11.37
    applied 331a9f9068c... mirrors: Add missing gitsm entries for yocto/oe mirrors
    applied 6b6d412f590... boost: fix native build with glibc-2.34
    applied 86285152bd6... python3-jinja2: Correct HOMEPAGE
    applied 38c55bd388e... tzdata: update to 2022a
    applied ce50594d709... bitbake: server/process: Disable gc around critical section
    applied b6ce93d565c... conf.py/poky.yaml: Move version information to poky.yaml and read in conf.py

openbmc-subtree update -c dunfell.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
