### PR TITLE
subtree update: 5ffb1169cb -> a515de07df

### DIFF
--- a/honister.conf
+++ b/honister.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = honister
-last_revision = c05ae80ba680887ac924c21536091be7a1173427
+last_revision = 9a0caf5b09e14a28a54c3f8524d97530aeb8152c
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = honister
-last_revision = 1584bddcf31f4bf3acc2304aa8dae927e8bec970
+last_revision = 378d4b6e7ba64b6a9a701457cc3780fa896ba5dc
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -20,5 +20,5 @@ last_revision = fb77606aef461910db4836bad94d75758cc2688c
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = honister
-last_revision = e0ab08bb6a32916b457d221021e7f402ffa36b1a
+last_revision = eff78b3802ffa7a0bff4c839752b147712da63ac
 


### PR DESCRIPTION
meta-openembedded c05ae80ba6 -> 9a0caf5b09:
    applied 79ab6d9df10... ebtables: remove perl from RDEPENDS
    applied fb6e3d3302d... graphviz: native: create /usr/lib/graphviz/config6 in populate_sysroot
    applied 0fb490a08ce... syslog-ng: adjust control socket location
    applied ecdf9c06643... cdrkit: remove ${PN} from ${PN}-dev RDEPENDS
    applied 8a6e7bdfd89... pw-am.sh: update to new patcwork system
    applied 061b7fc74f8... imagemagick: update SRC_URI branch to main
    applied af8cc48dc78... python3-django: upgrade 2.2.24 -> 2.2.27
    applied de18681d7dd... python3-django: upgrade 3.2.10 -> 3.2.12
    applied 0ea7cebacfe... libsrtp: Switch branch from master to main
    applied 1d0d23978a7... python3-lxml: upgrade 4.6.3 -> 4.6.5
    applied 7bd67a53af9... breakpad: fix branch for gtest in SRC_URI
    applied b83baa30b7f... htop: switch branch from master to main
    applied a19d1802b15... net-snmp: Avoid running `make clean` as it may fail
    applied c3d85c309be... apache2: upgrade 2.4.52 -> 2.4.53
    applied 9a0caf5b09e... zabbix: Fix sereval CVEs
poky e0ab08bb6a -> eff78b3802:
    applied 71985fb930f... releases: update to include 3.4.2
    applied 4947c6a8201... documentation: conf.py: update for 3.4.2
    applied b228df2e21e... bitbake: tests/fetch: Handle upstream master -> main branch change
    applied 3e935c2b101... gstreamer1.0: 1.18.5 -> 1.18.6
    applied a8238c379ee... gstreamer1.0-plugins-base: 1.18.5 -> 1.18.6
    applied b66bacb0b74... gstreamer1.0-plugins-good: 1.18.5 -> 1.18.6
    applied dc1b9fc4598... gstreamer1.0-plugins-bad: 1.18.5 -> 1.18.6
    applied 454f37cd18b... gstreamer1.0-plugins-ugly: 1.18.5 -> 1.18.6
    applied c9523e45455... gstreamer1.0-vaapi: 1.18.5 -> 1.18.6
    applied 445a80800a9... gstreamer1.0-libav: 1.18.5 -> 1.18.6
    applied 690d1f3ece9... gstreamer1.0-omx: 1.18.5 -> 1.18.6
    applied 88e71c839e7... gstreamer1.0-rtsp-server: 1.18.5 -> 1.18.6
    applied dc086a8f3d3... gstreamer1.0-python: 1.18.5 -> 1.18.6
    applied 0c8f4569e54... gst-devtools: 1.18.5 -> 1.18.6
    applied cab36b57c41... gst-examples: 1.18.5 -> 1.18.6
    applied 0ca6f8f3460... mc: fix build if ncurses have been configured without wide characters
    applied 30e330c259c... sdk: fix search for dynamic loader
    applied 3636ca3ff83... recipetool: Fix circular reference in SRC_URI
    applied 69c71187f3d... cve-check: create directory of CVE_CHECK_MANIFEST before copy
    applied 36815db5594... scripts/runqemu-ifdown: Don't treat the last iptables command as special
    applied 96515b53440... devtool: deploy-target: Remove stripped binaries in pseudo context
    applied 2fca57ba5eb... vim: Upgrade 4269 -> 4134
    applied b7ac5d205a2... binutils: Add fix for CVE-2021-45078
    applied 9b2fab0ac0a... linux-yocto/5.10: update to v5.10.96
    applied 4e2cfc6b111... virglrenderer: fix CVE-2022-0135 and -0175
    applied 58dd3fcada4... qemuboot: Fix build error if UNINATIVE_LOADER is unset
    applied 18d18cfea69... gcc : Fix CVE-2021-46195
    applied 3373a7a0fec... initramfs-framework: unmount automounts before switch_root
    applied 2dcbf103c75... gcc-target: fix glob to remove gcc-<version> binary
    applied d85d82e0637... libpcap: Disable DPDK explicitly
    applied 6b3103a8674... default-distrovars.inc: Switch connectivity check to a yoctoproject.org page
    applied 1c865e6646c... oeqa/buildtools: Switch to our webserver instead of example.com
    applied 83a57bcb417... linux-yocto/5.10: update to v5.10.99
    applied a51cf163777... linux-yocto/5.10: ppc/riscv: fix build with binutils 2.3.8
    applied db3ca363941... linux-yocto/5.10: fix dssall build error with binutils 2.3.8
    applied da086566125... linux-firmware: upgrade 20211216 -> 20220209
    applied 39083b60be5... expat: Upgrade 2.4.4 -> 2.4.5
    applied 9f5a29d644b... vim: Upgrade 8.2.4314 -> 8.2.4424
    applied b254be0f750... tiff: Add backports for two CVEs from upstream
    applied eb2e4583b66... expat: Upgrade 2.4.5 -> 2.4.6
    applied 0a26008bfc8... uninative: Upgrade to 3.5
    applied 0fbf414b39f... releases: update to include 3.3.5
    applied be127b9402b... harfbuzz: upgrade 2.9.0 -> 2.9.1
    applied ffc74bd7817... ruby: update 3.0.2 -> 3.0.3
    applied bf42579bd3c... libarchive: upgrade 3.5.1 -> 3.5.2
    applied 2cdb01ee20e... libarchive : update to 3.5.3
    applied 5a89035cf7a... ghostscript: fix CVE-2021-45949
    applied 3215578bf4e... perl: Improve and update module RPDEPENDS
    applied 1a08a672a80... libxml-parser-perl: Add missing RDEPENDS
    applied a164989b59f... devtool: explicitly set main or master branches in upgrades when available
    applied a8f021a18b1... depmodwrapper-cross: add config directory option
    applied 556aa4b56bf... coreutils: remove obsolete ignored CVE list
    applied 5eaa4463f12... wireless-regdb: upgrade 2021.08.28 -> 2022.02.18
    applied 16b4a5c2cbc... cve-check: get_cve_info should open the database read-only
    applied 8cd10efa78a... kernel-devsrc: do not copy Module.symvers file during install
    applied 9b0407c45ca... Revert "cve-check: add lockfile to task"
    applied 47d66569d7f... zip: modify when match.S is built
    applied e9ebc1ec9dc... selftest: recipetool: Correct the URI for socat
    applied bc68472e71b... quilt: Disable external sendmail for deterministic build
    applied 53f3bf5b785... cups: Add --with-dbusdir to EXTRA_OECONF for deterministic build
    applied 2d924cb91f2... rootfs-postcommands: amend systemd_create_users add user to group check
    applied 7a15c6e2a8d... asciidoc: update git repository
    applied f196ae90834... linux-yocto/5.10: features/zram: remove CONFIG_ZRAM_DEF_COMP
    applied a9dc338c370... linux-yocto/5.10: update to v5.10.101
    applied 4aa0d80c7a3... linux-yocto/5.10: Fix ramoops/ftrace
    applied 428a58000e2... linux-yocto/5.10: update to v5.10.103
    applied ef97194d303... expat: Upgrade 2.4.6 -> 2.4.7
    applied b0d76cd193d... bitbake: contrib: Fix hash server Dockerfile dependencies
    applied 981ecb069a2... bitbake: data_smart: Fix overrides file/line message additions
    applied 2b6574e7c43... bitbake: cooker: Improve parsing failure from handled exception usability
    applied b0f3d3b3655... bitbake: utils: Ensure shell function failure in python logging is correct
    applied 7872364e9e4... bitbake: fetch2: ssh: username and password are optional
    applied 2682eb50980... linux-yocto/5.10: update genericx86* machines to v5.10.99
    applied b091cc926ac... gcsections: add nativesdk-cairo to exclude list
    applied 7c3b93da9e1... sstate: inside the threadedpool don't write to the shared localdata
    applied 77140366fb8... vim: Update to 8.2.4524 for further CVE fixes
    applied 1ce1e56da13... wic: Use custom kernel path if provided
    applied 9124353019a... util-linux: update 2.37.2 -> 2.37.3
    applied 2c9e93bc40f... util-linux: upgrade 2.37.3 -> 2.37.4
    applied 630d754ea3d... patch.py: Prevent git repo reinitialization
    applied 984de2b68a0... ghostscript: fix CVE-2021-3781
    applied 036a9f92041... go: upgrade 1.16.13 -> 1.16.14
    applied 94966930e79... go: update to 1.16.15
    applied e872981a803... poky.conf: bump version for 3.4.3 honister release
    applied 60f6cb756d0... build-appliance-image: Update to honister head revision
    applied c17b457ac4f... documentation: prepare for 3.4.3 release
    applied ca162b5063a... docs: fix hardcoded link warning messages
    applied d3f32d15842... bitbake: build: Tweak exception handling for setscene tasks
    applied d8cd104e66e... crate-fetch: fix setscene failures
    applied ee68ae307fd... build-appliance-image: Update to honister head revision
    applied d349e4b75eb... toaster: Fix broken overrides usage
    applied 3467e4129cb... bitbake: server/xmlrpcserver: Add missing xmlrpcclient import
    applied 3e99ea91bfb... bitbake: toaster: Fix IMAGE_INSTALL issues with _append vs :append
    applied a5dea17662d... bitbake: toaster: fixtures replace gatesgarth
    applied 33cf6f26b22... conf/machine: fix QEMU x86 sound options
    applied e37119c3583... oe-pkgdata-util: Adapt to the new variable override syntax
    applied e38b37a03fe... linux-firmware: upgrade 20220209 -> 20220310
    applied bbbd9966e83... devupstream: fix handling of SRC_URI
    applied aea25b48763... pseudo: Add patch to workaround paths with crazy lengths
    applied 2b45d7d0ced... tiff: backport CVE fixes:
    applied 286f2c54872... linux-yocto: nohz_full boot arg fix
    applied 3f7e22d1b6c... linux-yocto/5.10: split vtpm for more granular inclusion
    applied 6631e784187... linux-yocto/5.10: cfg/debug: add configs for kcsan
    applied 2eda0c95c65... linux-yocto-rt/5.10: update to -rt61
    applied 6b3119b2587... linux-yocto/5.10: update to v5.10.107
    applied 21400a18cbf... gnu-config: update SRC_URI
    applied 0608a3fb0b2... virglrenderer: update SRC_URI
    applied 49c0883c91b... sanity: Add warning for local hasheqiv server with remote sstate mirrors
    applied 225f5139916... libxml2: move to gitlab.gnome.org
    applied bdeb3dcf94b... libxml2: update to 2.9.13
    applied cc07ce36fac... libxml2: fix CVE-2022-23308 regression
    applied 5033d9640db... grub: ignore CVE-2021-46705
    applied 03a4cea318e... oeqa/selftest/devtool: ensure Git username is set before upgrade tests
    applied f39012fed66... zlib: backport the fix for CVE-2018-25032
    applied 580532cfd0c... webkitgtk: update to 2.32.4
    applied 42735fc06da... bitbake: server/process: Disable gc around critical section
    applied eff78b3802f... conf.py/poky.yaml: Move version information to poky.yaml and read in conf.py
meta-raspberrypi 1584bddcf3 -> 378d4b6e7b:
    applied 378d4b6e7ba... linux-raspberrypi: Upgrade to 5.10.83

openbmc-subtree update -c honister.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
