### PR TITLE
subtree update: bdc6f55108 -> 5b7c1f7710

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,23 +2,23 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 1888971b1fcff1e86be175c2aac724c28d2840ca
+last_revision = 77c2fda04e406c210fe2a1870c8473748302bfb5
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 83f5577d8d8a5383642cd00a75ec56211596ecd2
+last_revision = c97a9e34abf23d871903481ac1867efec9abf090
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 498ca39cd69db8da0a03b30a865535d1ab047367
+last_revision = 93f2146211001ee3cf697d8428969cc3069ed6ba
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 30b38d9cb9262e1171746d4b538022b9ff86c307
+last_revision = 9e556960421c8bbe8851d9810352a5b4bd3b50df
 


### PR DESCRIPTION
meta-security 498ca39cd6 -> 93f2146211:
    applied 71fd7eda044... Upgrade parsec-service to 1.0.0 and parsec-tool to 0.5.2
    applied c010297b49e... tpm2-tools: fix missing version number
    applied f203d64c1f7... tpm2-openssl: update to 1.1.0
    applied 5855990d6f7... tpm2-tss: update to 3.2.0
    applied da8cbb3b164... tpm2-abrmd: update to 2.4.1
    applied f576e383796... tpm2-tss-engine: fix version string and build with openssl 3.0
    applied d4fffc44f3c... tpm2-pkcs11: update to 1.8.0
    applied 4158c871a6b... samhain.inc: Correct LICENSE to GPL-2.0-only
    applied 93f21462110... LICENSE: update to SPDX standard names
poky 30b38d9cb9 -> 9e55696042:
    applied 54fddf8d0aa... webkitgtk: update 2.34.6 -> 2.36.0
    applied 40d55d80ca3... epiphany: upgrade 41.3 -> 42.0
    applied c1c263eba29... webkitgtk: Add missing header locale.h
    applied dbe3a77e0db... python3: Do not detect multiarch when cross compiling
    applied d3544320ecf... qemu: Add fix for CVE-2022-1050
    applied 45afc335d33... tiff: Add marker for CVE-2022-1056 being fixed
    applied c362c7feef2... git: Ignore CVE-2022-24975
    applied 5c63147e31f... Revert "adwaita-icon-theme: upgrade 41.0 -> 42.0"
    applied 5fc8dd16f29... migration-guide: Kirkstone is now 4.0
    applied 3b2edd473eb... local.conf.sample: Update for 4.0 in sstate url
    applied 9fc670b6a12... linux-yocto: Remove unnecessary, commented out qemuarm entry
    applied 9dff569a074... externalsrc/devtool: Fix to work with fixed export funcition flags handling
    applied 6bef16bde3a... sanity: Show a warning that make 4.2.1 is buggy on non-ubuntu systems
    applied 4dbd32ccee7... itstool: correct upstream version check
    applied 32276b968ec... kernel-devsrc: Check for gen_vdso_offsets.sh before copying on riscv
    applied 7973b38018e... kernel: Delete unused KERNEL_LOCALVERSION variable
    applied 1186f02363c... kern-tools-native: add missing license
    applied ccfb5372c91... gmp: add missing COPYINGv3
    applied 39becfe5344... itstool: add missing COPYING.GPL3
    applied 2e3513e7cc7... libcap: add pam_cap license
    applied 1e3bda0517d... libsdl2: fix license
    applied dd360004e0b... libidn2: add Unicode-DFS-2016 license
    applied bd9defc50de... gettext: add MIT conditional as license
    applied 4e485ea7f29... python3-pip: correct license
    applied 4f7717ae09c... cmake: add missing licenses
    applied 0be2abfe7c9... runqemu: Allow auto detection of the correct graphics options
    applied 73d0fcf5d55... bitbake: checksum: Allow spaces in URI filenames
    applied d1f254d56fc... bitbake: fetch2/git: canonicalize ids in generated tarballs
    applied 6ec07ea6329... bitbake: fetch2: Add GIT_SSH_COMMAND to the list of exports
    applied 73fa855f6af... bitbake: ast: Improve function flags handling for EXPORT_FUNCTIONS
    applied 33b929192e7... bitbake: bitbake-diffsigs: make finding of changed signatures more robust
    applied c679713a729... bitbake: pyinotify.py: Simplify identification of which event has occurred
    applied a0ae56410c1... rxvt-unicode: Fix icon name
    applied 76f23d1d585... puzzles: Drop broken icon
    applied 564ff25c7cd... build-appliance-image: Update to master head revision
    applied 09fdbbcd193... linux-yocto-dev: update to v5.18+
    applied b3ea0a07d46... lttng-modules: support kernel 5.18+
    applied 3a694070f77... build-appliance-image: Update to master head revision
    applied 155295c1092... bluez5: Add fix for startup issues under systemd
    applied 81b4d8bc6bd... build-appliance-image: Update to master head revision
    applied af5cb9d6fed... bitbake: fetch2/crate: fix logger.debug line
    applied 24c743fe66c... shadow: Disable the use of syslog() for the native tools
    applied d3f246413b2... runqemu: Do not auto detect graphics if publicvnc is specified
    applied 3f8fd96cfd6... alsa-tools: Ensure we install correctly
    applied 5d6dff59473... libxshmfence: Correct LICENSE to HPND
    applied f3424b58e91... bitbake.conf: Correct BB_SIGNATURE_EXCLUDE_FLAGS
    applied 0674ae7bc46... git: Upgrade 2.35.1 -> 2.35.2
    applied 00cfdde791a... build-appliance-image: Update to master head revision
    applied 0e27bdf6407... documentation/brief-yoctoprojectqs: add directory for local.conf
    applied c6421fce9dc... dev-manual: add command used to add the signed-off-by line.
    applied 7b3a83f7369... docs: sphinx-static: switchers.js.in: remove duplicate for outdated versions
    applied 8643342d80a... docs: set_versions.py: add information about obsolescence of a release
    applied 57a32692b7e... docs: sphinx-static: switchers.js.in: improve obsolete version detection
    applied 8f48f1014f9... busybox: fix CVE-2022-28391
    applied 91e14d3a8e6... lua: fix CVE-2022-28805
    applied 399659d2c30... zlib: upgrade to 1.2.12
    applied 879914ec258... freetype: upgrade 2.11.1 -> 2.12.0
    applied 6f55b706978... ghostscript: upgrade 9.55.0 -> 9.56.1
    applied 26278afbd9d... libsoup: upgrade 3.0.5 -> 3.0.6
    applied 09ec0a480ee... libx11: upgrade 1.7.3.1 -> 1.7.5
    applied 099e417005f... acpica: upgrade 20211217 -> 20220331
    applied a405b7979e5... apt: upgrade 2.4.3 -> 2.4.4
    applied 350dd07b079... dpkg: upgrade 1.21.4 -> 1.21.7
    applied f528d9878a4... fontconfig: upgrade 2.13.1 -> 2.14.0
    applied ecbf60aa99f... mc: upgrade 4.8.27 -> 4.8.28
    applied 4ac64a54539... shared-mime-info: upgrade 2.1 -> 2.2
    applied 707c6b830de... strace: upgrade 5.16 -> 5.17
    applied 2e66ffdd77d... createrepo-c: upgrade 0.19.0 -> 0.20.0
    applied b534c7efd23... expat: upgrade 2.4.7 -> 2.4.8
    applied 8349e1e81bb... ethtool: upgrade 5.16 -> 5.17
    applied cfcbd686835... piglit: update to latest revision
    applied f290c19cc96... vulkan-samples: update to latest revision
    applied cd760d4d766... libxvmc: update 1.0.12 -> 1.0.13
    applied 2921dfb021d... libsndfile1: update 1.0.31 -> 1.1.0
    applied 313bdc0846a... at-spi2-core: update 2.42.0 -> 2.44.0
    applied 56e244abfb7... cmake: update 3.22.3 -> 3.23.0
    applied 639bd14a9cb... cmake: update license hashes
    applied d61e29347b8... gdk-pixbuf: upgrade 2.42.6 -> 2.42.8
    applied 0225e594766... librsvg: upgrade 2.52.7 -> 2.54.0
    applied 3a86cdd06b0... libgcrypt: upgrade 1.9.4 -> 1.10.1
    applied 1979152eaab... systemd-boot: remove outdated EFI_LD comment
    applied becb589ead7... sysvinit: upgrade 3.01 -> 3.02
    applied 5ef1642f20f... python3-dbusmock: upgrade 0.27.3 -> 0.27.5
    applied d1ecc1ed48c... python3-pip: upgrade 22.0.3 -> 22.0.4
    applied cbb01bd465c... llvm: update 13.0.1 -> 14.0.0
    applied 9481976d802... llvm: use default install paths
    applied d2e51251fae... qemuarm64: use virtio pci interfaces
    applied b48c0f03179... poky-tiny: enable qemuarmv5/qemuarm64 and cleanups
    applied ad529f66b3a... python3-zipp: upgrade 3.7.0 -> 3.8.0
    applied caea484eb82... python3-hypothesis: upgrade 6.39.5 -> 6.41.0
    applied 15df00f0f0e... selftest/lic_checksum: Add test for filename containing space
    applied abff42ff318... squashfs-tools: update 4.5 -> 4.5.1
    applied 6e4dec99104... buildtools-tarball: Only add cert envvars if certs are included
    applied e89cdd353a8... buildtools: Add standalone make tarball
    applied 721a6e44dac... babeltrace: Disable warnings as errors
    applied ac5477c4825... xserver-xorg: Fix build with gcc12
    applied 9b1f6a19982... systemtap: Fix build with gcc-12
    applied 996c17eb5b4... gnupg: Disable FORTIFY_SOURCES on mips
    applied 876430f8acc... wpa-supplicant: Reorder/group following style guide
    applied 254e75728b6... wpa-supplicant: Avoid changing directory in do_install
    applied 3f8f8cb1f63... wpa-supplicant: Use PACKAGE_BEFORE_PN/${PN}
    applied 12f63535bd2... wpa-supplicant: Backport libwpa/clean build fixes
    applied e88e746eb25... wpa-supplicant: Build static library if not DISABLE_STATIC
    applied 38f46f257f5... wpa-supplicant: Use upstream defconfig
    applied 4f2214775da... wpa-supplicant: Simplify build/install flow
    applied 46cdb52d7ff... wpa-supplicant: Package dynamic modules
    applied 0528d1f270b... python3-sphinx: upgrade 4.4.0 -> 4.5.0
    applied b66928407af... libbsd: upgrade 0.11.5 -> 0.11.6
    applied 5d55cebe61f... riscv: Add tunes for rv64 without compressed instructions
    applied 4dea2ee73e8... mdadm: Drop clang specific cflags
    applied 6b8101d296f... harfbuzz: Upgrade to 4.2.0
    applied 0e1093e0484... pango: Upgrade to 1.50.6
    applied 29d26db6679... pango: Drop using additional cflags with clang
    applied b550a21a665... pango: Skip test-layout ptest
    applied 4a3f3f2c349... apt: add apt selftest to test signed package feeds
    applied af0655441f8... package_manager: fix missing dependency on gnupg when signing deb package feeds
    applied f98f758c125... git: correct license
    applied 1fa96754413... ncurses: use COPYING file
    applied e4b2dd51a41... webkitgtk: adjust patch status
    applied f72889eb00f... recipetool: Do not use mutable default arguments in Python
    applied 41fd30c4306... create-spdx: fix error when symlink cannot be created
    applied c7e0e7e7168... u-boot: Correct the SRC_URI
    applied 73cdd40c9e3... u-boot: Inherit pkgconfig
    applied 72bb57ed0ba... update_udev_hwdb: fix multilib issue with systemd
    applied 79d8fb1da2d... boost: upgrade 1.78.0 -> 1.79.0
    applied a79f1436846... enchant2: upgrade 2.3.2 -> 2.3.3
    applied 52bee892b5d... help2man: upgrade 1.49.1 -> 1.49.2
    applied a6886f023a2... json-c: upgrade 0.15 -> 0.16
    applied bb8996e6b9b... libaio: upgrade 0.3.112 -> 0.3.113
    applied e143c8f8b21... libusb1: upgrade 1.0.25 -> 1.0.26
    applied f9774a7178e... libgit2: upgrade 1.4.2 -> 1.4.3
    applied 0768ac21014... libcap: upgrade 2.63 -> 2.64
    applied bb0ec4a2cf3... linux-firmware: upgrade 20220310 -> 20220411
    applied c5c23731468... mtools: upgrade 4.0.38 -> 4.0.39
    applied 258f620ff1a... libpcre2: upgrade 10.39 -> 10.40
    applied bab5779e915... git: upgrade 2.35.2 -> 2.35.3
    applied 6d46321a151... openssh: upgrade 8.9p1 -> 9.0p1
    applied 9917bbee0d2... wireless-regdb: upgrade 2022.02.18 -> 2022.04.08
    applied 20e64650d6e... ruby: upgrade 3.1.1 -> 3.1.2
    applied 57b11d17247... bitbake: providers: use local variable for packages_dynamic pattern
    applied 51ed090de1a... bitbake: fetch2/git: Simplify the validation of SHA-1 revisions
    applied ebb14f9530c... poky-tiny: add a distro description
    applied a6ebbe3a10f... poky: Use INIT_MANAGER in main distro config
    applied 8dc1f28aa10... go: Upgrade to 1.18
    applied ab9be8acf4a... go: Drop GOBUILDMODE
    applied 4e0d6af8322... go: Disable pie in cgo for mips
    applied 4eeb2afd0e3... go-target: Pass -trimpath to go linker
    applied f9918348482... go-helloworld: update to latest revision
    applied 460012e04a8... go: Always pass interpreter to linker
    applied 36ccca5cba0... docs: set_versions.py: fix latest release of a branch being shown twice in switchers.js
    applied b5882ec9083... docs: set_versions.py: fix latest version of an active release shown as obsolete
    applied 7cbd9f847df... python3-jsonpointer: upgrade 2.2 -> 2.3
    applied 9e87e26379d... python3-sphinx-rtd-theme: upgrade 0.5.0 -> 1.0.0
    applied 41984559c8f... glibc: ptest: Fix glibc-tests package issue
    applied a4df7ceead5... dropbear: upgrade 2020.81 -> 2022.82
    applied 2e269144c9f... gptfdisk: upgrade 1.0.8 -> 1.0.9
    applied 1c688b10496... kexec-tools: upgrade 2.0.23 -> 2.0.24
    applied 7112e20cd2e... openssl: extract legacy provider module to a separate package
    applied f422dabbd71... libgpg-error: Add ptest
    applied 7a386594437... repo: upgrade 2.22 -> 2.23
    applied 42ed634570c... qemu: backport a patch to optionally disable i8042 (AT and PS/2) hardware
    applied eccb34f80cb... qemux86-64: disable legacy i8042 (AT keyboard, PS/2 mouse)
    applied e64ee2d2a24... seatd: Disable overflow warning as error on ppc64/musl
    applied a807ba311d9... gstreamer1.0-plugins-bad: drop patch
    applied b82be52b5d8... libxcursor: upgrade 1.2.0 -> 1.2.1
    applied 4db76e434bd... mkfontscale: upgrade 1.2.1 -> 1.2.2
    applied 9c4de1482f1... xdpyinfo: upgrade 1.3.2 -> 1.3.3
    applied a041cb4ea59... docs: update Bitbake objects.inv location for master branch
    applied 8245b2b1d5e... docs: set_versions.py: mark as obsolete only branches and old tags from obsolete releases
    applied 63e717738fb... docs: sphinx-static: switchers.js.in: rename all_versions to switcher_versions
    applied ee6718fe086... docs: sphinx-static: switchers.js.in: fix broken switcher for branches
    applied 57b80a8a9a2... docs: sphinx-static: switchers.js.in: do not mark branches as outdated
    applied ab6fce5a33a... bitbake: bitbake-diffsigs: Make PEP8 compliant
    applied 9e113e175b4... automake: Drop redundant 'u' flag in ARFLAGS
    applied f2016af0399... package.bbclass: Prevent perform_packagecopy from removing /sysroot-only
    applied ce94e33aef1... kernel-yocto.bbclass: Fixup do_kernel_configcheck usage of KMETA
    applied d0fc375250c... linux-firmware: correct license for ar3k firmware
    applied d00aa3c8d16... linux-firmware: split ath3k firmware
    applied a9808dfbe91... arch-armv8-2a.inc: fix a typo in TUNEVALID variable
    applied 372ceb2321b... arch-armv8-4a.inc: add tune include for armv8.4a
    applied d951d478b83... bitbake: tests/parse: Fix one test overwriting another
    applied a2e0ed2cbf5... bitbake: server/process: Drop unused import
    applied 4431ad28025... bitbake: ui/buildinfohelper: Drop unused import
    applied 8a3fe334384... bitbake: cooker: Drop unused loop
    applied ebf1e905013... bitbake: msg: Drop unused local variable
    applied 004b0e03e11... bitbake: buildinfohelper: Drop unused function
    applied d2ea881a00d... bitbake: fetch2/crate: Drop unused import
    applied 509090fd3eb... bitbake: siggen: Drop pointless break statement
    applied ff9f30b4c63... bitbake: ui/knotty: Drop pointless pass statement
    applied d796985f804... bitbake: persist_data: Use a valid exception for missing implementation
    applied 6d1d9f3d78f... bitbake: runqueue: Drop pointless variable assignment
    applied cbeda8ee3bb... bitbake: buildinfohelper: Drop unused variables
    applied 21559199516... install/devshell: Introduce git intercept script due to fakeroot issues
    applied 07c627645da... poky/meta-yocto-bsp: Post release version/codename updates
    applied 7f89c7f9290... xorg-app: Tweak handling of compression changes in SRC_URI
    applied 44a36caa7c2... gcc: Upgrade to 11.3 release
    applied fba37dce433... musl: Fix build when usrmerge distro feature is enabled
    applied a8d664c7a12... gcompat: Fix build when usrmerge distro feature is enabled
    applied 408776f94e6... apt: upgrade 2.4.4 -> 2.4.5
    applied 801b8a29700... python3-hypothesis: upgrade 6.41.0 -> 6.44.0
    applied 8809c23a6b0... wpa-supplicant: Install wpa_passphrase when not disabled
    applied 146bb6b235c... wpa-supplicant: Package shared library into wpa-supplicant-lib
    applied 5ec6839709f... wic: do not use PARTLABEL for msdos partition tables
    applied 11025bed13d... migration-3.4: add missing entry on EXTRA_USERS_PARAMS
    applied 30b4b153d61... ref-manual: add a note about hard-coded passwords
    applied 0dd9a182ace... ref-manual: mention wildcarding support in INCOMPATIBLE_LICENSE
    applied 71fafac324f... ref-manual: add mention of vendor filtering to CVE_PRODUCT
    applied c3067e46c08... ref-manual: add KERNEL_DEBUG_TIMESTAMPS
    applied d89fbdfd16a... ref-manual: add empty-dirs QA check and QA_EMPTY_DIRS*
    applied f84b6a775c7... migration-guides: complete migration guide for 4.0
    applied c1496e2268c... migration-guides: add release notes for 4.0
    applied e2cb52612e3... ref-manual: Add XZ_THREADS and XZ_MEMLIMIT
    applied d653a436654... ref-manual: add ZSTD_THREADS
    applied 57e245dd090... docs: conf.py: fix cve extlinks caption for sphinx <4.0
    applied 78874e0126f... docs: ref-manual: variables: add hashed password example in EXTRA_USERS_PARAMS
    applied ee65af56741... docs: migration-guides: migration-3.4: mention that hardcoded password are supported if hashed
    applied 9339b864f32... docs: migration-guides: release-notes-4.0: fix risc-v typo
    applied 2d951f8f4f8... docs: migration-guides: release-notes-4.0: replace kernel placeholder with correct recipe name
    applied 32cf5343f77... migration-guides: release-notes-4.0: update 'Repositories / Downloads' section
    applied a3e459ca588... releases: update for yocto 4.0
    applied 5639708757f... set_versions: update for 4.0 release
    applied 2ef5a649cfa... libc-glibc: Use libxcrypt to provide virtual/crypt
    applied d32aa383f42... glibc: Update to latest 2.35 tip
    applied 468b7327030... qemu.bbclass: Extend ppc/ppc64 extra options
    applied 5eba125ddec... busybox: Use base_bindir instead of hardcoding /bin path
    applied 53dca17ec3e... e2fsprogs: fix CVE-2022-1304
    applied 7bd13c6a089... subversion: upgrade to 1.14.2
    applied 7c464759540... python3: ignore CVE-2015-20107
    applied d70d41b1608... gstreamer1.0-plugins-good: Fix libsoup dependency
    applied 490bec3d506... gstreamer1.0: Minor documentation addition
    applied 1e48a0e4389... terminal.py: Restore error output from Terminal
    applied d7300f37a37... devshell.bbclass: Allow devshell & pydevshell to use the network
    applied ba14e497597... musl-locales: Add package
    applied 57627d99bdb... cases/buildepoxy.py: fix typo
    applied e464cc46bcd... set_versions: Add a getlatest command to obtain the latest release branch name
    applied 284b61d3867... create-spdx: delete virtual/kernel dependency to fix FreeRTOS build
    applied 9c745b6a4c9... go.bbclass: disable the use of the default configuration file
    applied c2f2e2e633c... meta-poky: update conf-notes.txt
    applied 0436965a402... layer.conf: Post release codename changes
    applied 5546a868b52... base: Drop git intercept
    applied 5bca57859b2... bitbake.conf: mark all directories as safe for git to read
    applied 1bd70f469de... bitbake: fetch2/osc: Add missing parameter
    applied 98a4a4a613d... bitbake: fetch2/ssh.py: decode path back for ssh
    applied 8c42eaa2e09... overview-manual: licensing section fixes
    applied a19ee036110... manuals: correct and improve descriptions of Autotools
    applied c6445c3aa17... manuals: refer to "YP Compatible" layers instead of "curated" ones
    applied 261f9b57091... migration-guides: stop including documents with ".. include"
    applied 7838c778af2... migration-guides: release-notes-4.0: mention LTS release
    applied 0bd00122643... rust: update 1.59.0 -> 1.60.0
    applied 936b3f79cde... zlib: Add patch to fix building icedtea7-native from meta-java
    applied ae37e2efd32... neard: Switch SRC_URI to git repo
    applied 4e9102a83cd... wic: Add dependencies for erofs-utils
    applied d9298983021... sanity: skip make 4.2.1 warning for debian
    applied 0ec65a3eca7... util-linux: Create u-a symlink for findfs utility
    applied f33973e591e... releases: update to include 3.3.6
    applied 51f7dfe9145... staging: Ensure we filter out ourselves
    applied fa553eb6433... cve_check: skip remote patches that haven't been fetched when searching for CVE tags
    applied f461424b52a... libxml2: update patch status
    applied 10ddcd62cd9... python3-psutil: submit patch upstream
    applied 3121cf14b92... gnu-config: update to latest revision
    applied 220c52e0565... go-helloworld: update to latest revision
    applied 4bcc9c79a86... piglit: update to latest revision
    applied 00bb4e2a8bb... vulkan-samples: update to latest revision
    applied e561c18805b... python3-typing-extensions: upgrade 3.10.0.0 -> 4.2.0
    applied 2a791efa59d... python3-pyparsing: upgrade 3.0.7 -> 3.0.8
    applied 0f299861704... glib: upgrade 2.72.0 -> 2.72.1
    applied b3c193e5d51... go: update 1.18 -> 1.18.1
    applied 4c775f712ff... meson: update 0.61.3 -> 0.62.1
    applied c9067501519... icu: update 70.1 -> 71.1
    applied d88d5c978d5... valgrind: update 3.18.1 -> 3.19.0
    applied 0284c59c410... libcap-ng: update 0.8.2 -> 0.8.3
    applied 2099f3b1afe... libgpg-error: 1.44 -> 1.45
    applied f33c2104a3a... cmake: update 3.23.0 -> 3.23.1
    applied 9dcf905034e... stress-ng: upgrade 0.13.12 -> 0.14.00
    applied ddda3af6a1c... llvm: update 14.0.0 -> 14.0.1
    applied 4e2c92c6893... cve-check: no need to depend on the fetch task
    applied 3168b02b086... poky.conf: set PACKAGE_CLASSES explicitly to package_rpm
    applied 7a30031f696... image.bbclass: allow overriding dependency on virtual/kernel:do_deploy
    applied de067dac1d5... pulseaudio: conditionally depend on alsa-plugins-pulseaudio-conf
    applied 7896b14e4ca... kmod: Enable xz support by default
    applied e141d586f2c... lib/sstatesig: Fix find_siginfo to match sstate filename generation
    applied 1ecaf468157... go-helloworld: remove unused GO_WORKDIR
    applied a0b8419a7cc... bitbake: runqueue: Fix sig file location when using multiconfig
    applied d9dc50ccff3... distro/poky-tiny: don't put translations into images
    applied 33df924c002... scripts/contrib/oe-build-perf-report-email.py: remove obsolete check for phantomjs and optipng
    applied 5b5ccb7bced... kernel-yocto: allow patch author date to be commit date
    applied c9ad977a0b5... curl: Update to 7.83.0
    applied f2022327f4d... license_image.bbclass: Make QA errors fail the build
    applied c81eec622d1... musl-locales: explicitly depend on gettext-native
    applied 2af5b0a58e3... eudev: Remove unused files
    applied fc80c5ee16d... sed: Specify shell for "nobody" user in run-ptest
    applied b08c60224fa... base-passwd: Disable shell for default users
    applied 95b9fc5ddc1... strace: Don't run ptest as "nobody"
    applied 892b126ef4d... volatile-binds: Change DefaultDependencies from false to no
    applied 9e556960421... volatile-binds: Remove TimeoutSec and allow DefaultTimeoutSec to be used
meta-openembedded 1888971b1f -> 77c2fda04e:
    applied b420d9f2213... frr: add recipe
    applied 602eddeefc9... htpdate: update to 1.3.3
    applied 43dbadb6a28... nbdkit: upgrade 1.25.7 -> 1.30.2
    applied 611a99c0360... nftables: add ptest
    applied 763af22a346... icewm: upgrade 2.9.0 -> 2.9.6
    applied fef412b06ce... lapack: upgrade 3.9.0 -> 3.10.0
    applied 568d2f6dfc0... libbpf: upgrade 0.5.0 -> 0.7.0
    applied fb16244c4aa... libmtp: upgrade 1.1.18 -> 1.1.19
    applied ed87caf2933... logwatch: upgrade 7.5.3 -> 7.6
    applied fc45d159ef0... mpich: upgrade 3.4.3 -> 4.0.2
    applied 30c9e70e6b3... libnma: upgrade 1.8.36 -> 1.8.38
    applied 7383507da30... gnome-control-center: upgrade 41.2 -> 42.0
    applied 4efc34bdfd6... gnome-flashback: upgrade 3.42.1 -> 3.44.0
    applied 217707b4229... gnome-panel: upgrade 3.42.0 -> 3.44.0
    applied fd727e27e0b... gnome-session: upgrade 41.3 -> 42.0
    applied d1177234732... gnome-shell-extensions: upgrade 41.1 -> 42.0
    applied bad130a8dfa... gthumb: upgrade 3.12.0 -> 3.12.2
    applied a48c6c98e80... ibus: upgrade 1.5.23+ -> 1.5.26
    applied 66317bbb056... libportal: upgrade 0.5 -> 0.6
    applied eab0d95d1c1... network-manager-applet: upgrade 1.24.0 -> 1.24.0
    applied d407f466386... sysprof: upgrade 3.42.1 -> 3.44.0
    applied dfbad36491e... gnome-shell: fix bluetooth PACKAGECONFIG
    applied 2a14032c58d... packagegroup-gnome-desktop: replace gnome-bluetooth by gnome-bluetooth4
    applied 7751b4bb143... gnome-bluetooth: avoid clashes with gnome-bluetooth4
    applied e6f43e79953... icewm:include imlib2-loaders package
    applied b51d4b6d68d... dbus-cxx: Include missing <utility> header
    applied c535b7e8797... safec: Upgrade to 3.7.1
    applied 6904c37d298... mongodb: Update to 4.4.13
    applied 30523727a33... redis: upgrade to 7.0-rc3
    applied a0aaf7a23a8... libkcapi: Upgrade to 1.4.0
    applied bb71d973018... libpfm4: Remove -Werror from compiler flags
    applied c03a543d93d... parallel-deqp-runner: Fix build with gcc 12
    applied 4cde452b197... glmark2: Fix build with gcc12
    applied ffba3bbe131... memcached: Upgrade to 1.6.15
    applied 66fdbc25c13... tvheadend: Update to latest trunk
    applied 6f5d694d9c3... ot-br-posix: Disable Wsign-compare for clang
    applied a89b57aa45b... gnome-bluetooth: rename recipes to avoid suffix in future
    applied e6ba5bc0d88... gnome-bluetooth: Add PACKAGECONFIG pulseaudio and filter by distro-feature
    applied 576fba53473... libldb: upgrade 2.3.2 -> 2.3.3
    applied 748d2d0c7cf... samba: upgrade 4.14.12 -> 4.14.13
    applied ee3b2e19a6f... frr: install correct initscript
    applied 83b283c5282... opensaf: Fix build with gcc 12
    applied 026be53fba2... boost-sml: Disable examples
    applied 5288d38ee66... mpich: Add new directory modules/hwloc/config to search path
    applied 6892fc010ab... gnulib: Do not use git operations to install the sources
    applied 1a2c6588433... sysprof: Fix build to work with llvm libunwind
    applied 509d74f2d3d... libvpx: upgrade 1.8.2 -> 1.11.0
    applied f0f0279187a... linuxconsole: upgrade 1.7.0 -> 1.7.1
    applied 6c51fe70fa4... mercurial: upgrade 5.5 -> 6.1
    applied be76cc297fa... ocl-icd: upgrade 2.3.0 -> 2.3.1
    applied e4df09949bc... octave: upgrade 6.4.0 -> 7.1.0
    applied edb3ef57ec4... phoronix-test-suite: upgrade 10.8.1 -> 10.8.2
    applied 139cc116053... pkcs11-helper: fix PV
    applied 515ccda4335... rdma-core: upgrade 39.0 -> 40.0
    applied d42f5c19920... pam-plugin-ldapdb: upgrade 1.3 -> 1.3.1
    applied 4b1149fe196... pax-utils: upgrade 1.2.2 -> 1.3.3
    applied 3cf9b6386e8... pcsc-tools: upgrade 1.5.8 -> 1.6.0
    applied 400b2f9d7e2... pegtl: upgrade 3.2.1 -> 3.2.5
    applied 85c39388c30... qpdf: upgrade 10.5.0 -> 10.6.3
    applied 2cbfe9ffcf7... s-nail: upgrade 14.9.23 -> 14.9.24
    applied 08d9e915425... openjpeg: fix CVE-2022-1122
    applied 884f5aed87b... linuxconsole: Fix makefile issue found with clang
    applied 52077cd6747... smcroute: upgrade 2.5.4 -> 2.5.5
    applied b2d963ea14b... squashfs-tools-ng: upgrade 1.0.2 -> 1.1.4
    applied d5cc09d682a... st: upgrade 0.8.4 -> 0.8.5
    applied 7d7848e8c0e... tracker: upgrade 3.2.1 -> 3.3.0
    applied 4ee804f20b0... thingsboard-gateway: upgrade 2.8 -> 2.9
    applied 84a8a0ce1e0... thrift: upgrade 0.14.2 -> 0.16.0
    applied c4f3039744e... toybox: upgrade 0.8.5 -> 0.8.6
    applied 2e0f15d3f48... mongodb: Fix aarch64 build with gcc12
    applied 1ea6259c8ee... unbound: upgrade 1.13.2 -> 1.15.0
    applied d4a841dc033... twm: upgrade 1.0.11 -> 1.0.12
    applied a24e224975d... unixodbc: upgrade 2.3.7 -> 2.3.9
    applied 68e5bb81eb8... xterm: upgrade 368 -> 372
    applied 26a042d4368... gnome-backgrounds: upgrade 41.0 -> 42.0
    applied 3f923023420... gnome-settings-daemon: upgrade 41.0 -> 42.1
    applied 8e1986e95ad... clinfo: Upgrade 2.2.18.04.06 -> 3.0.21.02.21
    applied e1036f24a32... python3-imgtool: update to 1.9.0
    applied 9a6cc59e571... python3-google-api-python-client: upgrade 2.42.0 -> 2.43.0
    applied d96c65e7128... python3-googleapis-common-protos: upgrade 1.54.0 -> 1.56.0
    applied cdb5c21bada... python3-nocaselist: upgrade 1.0.4 -> 1.0.5
    applied 5c9742f6f42... python3-pylint: upgrade 2.13.2 -> 2.13.5
    applied 81ba04a7ee9... python3-redis: upgrade 4.2.1 -> 4.2.2
    applied ad41b4a0693... python3-sentry-sdk: upgrade 1.5.7 -> 1.5.8
    applied e95728476b1... python3-sqlalchemy: upgrade 1.4.34 -> 1.4.35
    applied 1805056eb83... python3-nocasedict: upgrade 1.0.2 -> 1.0.3
    applied eef9ef6b875... python3-graphviz: upgrade 0.19.1 -> 0.19.2
    applied 6fbe7f74870... python3-kivy: upgrade 2.0.0 -> 2.1.0
    applied 9864902a15f... libgweather4: Fix introspection build
    applied 159fd281968... gjs: Add cairo to DEPENDS unconditionally
    applied c1b69601fd5... tgt: move from meta-openstack
    applied 55ba2545a0b... libconfig-general-perl: move from meta-openstack
    applied c2bb39f4394... audit: Upgrade 3.0.6 -> 3.0.7
    applied 74e6d15ad14... mosh: Drop perl dependencies from server
    applied 6ece0f38b01... gnome-shell-extensions: Stop copying gnome-classic session to wayland
    applied 33f4142dff5... libcereal: Link libatomics with gcc as well
    applied 04b707ed5b3... wpantund: Add missing dependency on boost
    applied e50dd7da23b... poco: upgrade 1.11.1 -> 1.11.2
    applied f4e628c81e3... gimp: Disable vector icons on 32bit systems
    applied 0bb3d4b6a06... gnuplot: inherit pkgconfig
    applied 317d7407967... mozjs-91: Upgrade to 91.8.0
    applied 26222766ba3... mozjs-78: Switch to system libicu
    applied 5a52bffde19... nodejs: Upgrade to 16.14.2
    applied 47d2307ae77... ot-br-posix: Fix build with gcc
    applied 62a60f91aaf... dlt-daemon: Fix build on rv32/rv64
    applied 1d7385bba58... grpc: Fix build with rv32/rv64
    applied cf260fb4ed6... gpsd: Only copy the Python files if they are created
    applied 89bc6331f4b... ltrace: Fix build on ppc64 with gcc12
    applied fa5922c1cb6... opencv: Fix build with gcc-12 on ppc64
    applied 5fa0188b8c7... poppler: Support building for native
    applied 4c6b0afe568... netdata: version bump 1.33.1 -> 1.34.1
    applied 667219409ff... gpsd: split python utils from gps-utils
    applied cc8efa1fe95... mozjs-91: Disable strip
    applied a4e7ad4568f... mozjs-91: Add option to use system ICU
    applied 12058113c4d... sysprof: Remove libunwind on rv32
    applied b3be90be2f6... python3-cppy: upgrade 1.2.0 -> 1.2.1
    applied 674306a4296... python3-blivetgui: use symbolic list-add and edit- icons
    applied 9881151e804... python3-bitstruct: Upgrade 8.13.0 -> 8.14.0
    applied a1b80175b36... python3-marshmallow: Upgrade 3.14.1 -> 3.15.0
    applied a2683269de7... python3-aenum: upgrade 3.1.8 -> 3.1.11
    applied c6022c3ffb9... python3-aws-iot-device-sdk-python: upgrade 1.5.1 -> 1.5.2
    applied 0f00037a201... python3-cmd2: upgrade 2.4.0 -> 2.4.1
    applied bc92c3e7187... python3-django: upgrade 2.2.27 -> 2.2.28
    applied 35f0d19d4f3... python3-imageio: upgrade 2.16.1 -> 2.17.0
    applied b932a20f26e... drbd-utils: fix for usrmerge
    applied ec6d0735186... sdbus-c++-libsystemd: bugfix dev package is not installed
    applied 64156a6f8f3... gpsd: Correct the creation of the gps-utils-python package
    applied c7ce2371c02... crash: Upgrade to 8.0.0
    applied 224d8a8cbee... crash: Fix build for mips target
    applied e059bf5da05... tcsh: Do not install symlinks into /bin with usrmerge
    applied 2b643dcefe8... arno-iptables-firewall: Do not use bitbake variable inside S
    applied ae8e0ae77f7... fluentbit: Fix build with usrmerge distro feature
    applied 8c7ffffa07d... tomoyo-tools: Define SBINDIR
    applied 984bc7eaca6... tomoyo-tools: Drop md5sum
    applied 682657248c6... gradm: Upgrade to 3.1-202111052217
    applied f91983f1f3e... babeld: Upgrade to 1.11
    applied 4448cd9ee7e... scsirastools: Fix build with usrmerge
    applied 8cec1f1fd9e... dietsplash: specify install rootdir
    applied d69c0da9d2a... linux-atm: Add knob to root prefix
    applied a47c8331263... ufw: Fix build with usrmerge distro feature
    applied 5f6156c0ef8... libldb: Fix installed-vs-shipped and rebuild error
    applied 1f56482ecf8... netdata: Fix build errors with clang
    applied 6a52b84dbc4... klibc: Recognise --dyld-prefix clang option
    applied 78180b6c216... mozjs: Use vendored icu on ppc/clang
    applied b8e97f5b2a1... boinc-client: Do not overwrite same file when using usrmerge
    applied 088e4017987... pam-ssh-agent-auth: Use specific versions of BSD licenses
    applied 1fa927eba97... fwupd: Enable build with musl
    applied 4aa174ef75a... evince: upgrade 42.1 -> 42.2
    applied 1a9c78999b2... evolution-data-server: upgrade 3.44.0 -> 3.44.1
    applied 2e84305baaf... gspell: upgrade 1.9.1 -> 1.10.0
    applied 98840e726d2... gtksourceview5: upgrade 5.4.0 -> 5.4.1
    applied 6d73127ced1... libadwaita: upgrade 1.1.0 -> 1.1.1
    applied 2ff1569067c... nautilus: upgrade 42.0 -> 42.1.1
    applied 57089566e3f... frr: add PACKAGECONFIG for fpm
    applied b82354a2acc... htpdate: upgrade 1.3.3 -> 1.3.4
    applied 7c0a36e48d5... nanomsg: upgrade 1.1.5 -> 1.2
    applied 97c56a04dd7... nbdkit: upgrade 1.30.2 -> 1.31.1
    applied f18dd93373b... ctags: upgrade 5.9.20220410.0 -> 5.9.20220417.0
    applied c4d4e192f48... hexedit: upgrade 1.5 -> 1.6
    applied e6c70cfa11f... lapack: upgrade 3.10.0 -> 3.10.1
    applied c41c8112b6e... links: upgrade to 2.26
    applied 4812d74accb... lsscsi: upgrade 0.31 -> 0.32
    applied bfd4f628c41... openwsman: upgrade 2.6.11 -> 2.7.1
    applied 8e926e200b0... libdbd-sqlite-perl: upgrade 1.68 -> 1.70
    applied a21bab91bd8... libencode-perl: upgrade 3.16 -> 3.17
    applied e709705f411... libextutils-cppguess-perl: upgrade 0.23 -> 0.26
    applied ddb6ca36b82... libtest-harness-perl: upgrade 3.42 -> 3.44
    applied dafc1efa157... ostree: upgrade 2021.6 -> 2022.2
    applied f2748082e84... makedumpfile: Upgrade to 1.7.1
    applied f0d0034e269... lirc: install systemd units only when using systemd distro feature
    applied f9a935ac8e0... fluentbit: Disable systemd support when systemd distro feature is disabled
    applied 3c1c07e9a54... absil-cpp: Update SRC_URI to to the latest google internal sync
    applied bcfec90e909... gtksourceview5: Allow wayland or x11
    applied 3b311b6c1ec... gtkmm3: Allow wayland or x11 in distro features
    applied 528b1699ec2... gparted: Allow wayland or x11 distro features
    applied 5255b6a0d93... lirc: Delete systemd unit files on non systemd distros
    applied 572510de18c... atkmm: Allow build with wayland
    applied 9abe74eb0bd... pangomm: Allow building with wayland
    applied 19c6b9a3243... cdrkit: add new option -eltorito-platform for genimageiso
    applied 9754901bb0b... pipewire: Upgrade to version 0.3.50
    applied aea550e75db... lockdev: Drop cumulative debian patch
    applied bbc6fa72c37... boinc-client: Make script install not depend on host install paths
    applied c7cd5c29438... babl: Fix build with meson 0.62+
    applied 2e43c121455... libesmtp: Disable NTLM support by default
    applied 73d50d2b4b6... meta-oe-image: fix build depends
    applied 09a97158f80... frr: inherit autotools-brokensep instead of autotools
    applied 77c2fda04e4... conntrack-tools: Fix missing capability
meta-raspberrypi 83f5577d8d -> c97a9e34ab:
    applied 3a91ee04ebb... docs: link to latest documentation of kas
    applied 893aad8ce89... python3-sense-hat: Use specific BSD license
    applied 70ea7a678aa... raspberrypi-firmware: Update to 20220331
    applied 49ad2d8bee9... linux-raspberrypi: Update 5.15 recipe to 5.15.34
    applied 4f356af004e... linux-raspberrypi: Update 5.10 recipe to 5.10.110
    applied 7da2c1886e1... bcm2835: Update to 1.71
    applied a92429d9509... pi-blaster: Uprev the recipe
    applied 97101ee4fb4... linux-firmware-rpidistro: Update to 20210315-3+rpt4
    applied dda2c3a73ed... raspi-gpio: Uprev revision to current HEAD of master branch
    applied cbb15c7a34b... python3-rtimu: Upgrade to 7.2.1
    applied 34c1d4739d6... rpio: Upgrade to 0.10.1
    applied 7a3e4193f13... python3-adafruit-pureio: Uprade to 1.1.8
    applied e6209f5671a... python3-adafruit-platformdetect: Upgrade to 3.22.1
    applied b90b06785c4... python3-adafruit-circuitpython-register: Upgrade to 1.9.8
    applied 82871068c25... rpi-basic-image: Drop image
    applied 258dcb3e15f... rpi-hwup-image: Drop image
    applied 61ad24a65ec... packagegroup-rpi-test: Include more packages
    applied 993436b0feb... ci: Use test builds with the test image
    applied c3275986b6d... u-boot: Remove the randundant patch
    applied 901cb604b5e... bluez-firmware-rpidistro: Add compatibility to oe-core/create-spdx
    applied 785181f6955... docs: Drop mention of deprecated images
    applied ad6ebc053ab... docs: Bump copyright year
    applied 0135a02ea57... rpi-base.inc: Add MCP3008 ADC overlay
    applied c97a9e34abf... kmod: Enable xz compression

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
