### PR TITLE
kirkstone subtree update: e22d42c0b6 -> 322e9fc9c6

### DIFF
--- a/kirkstone.conf
+++ b/kirkstone.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = kirkstone
-last_revision = bb2b5b31a80eb164e47649036878773614e4dbdf
+last_revision = 5357c7a40eaf8d1bcf7ff58edbba8e9527e40c7d
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,5 +20,5 @@ last_revision = 93f2146211001ee3cf697d8428969cc3069ed6ba
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = kirkstone
-last_revision = 27de52e402ae000dfa502d52908cd6e6aef923ec
+last_revision = d84c73d1ef05b7e12bcab2767f1a1f7a59ad17f2
 


### PR DESCRIPTION
poky 27de52e402 -> d84c73d1ef:
    applied 881a9d82e75... e2fsprogs: fix CVE-2022-1304
    applied ed9500ddb6a... python3: ignore CVE-2015-20107
    applied 498bbee789f... cve_check: skip remote patches that haven't been fetched when searching for CVE tags
    applied a869054e4e4... apt: upgrade 2.4.4 -> 2.4.5
    applied 275c29d9308... subversion: upgrade to 1.14.2
    applied bdbca4b3af3... glib: upgrade 2.72.0 -> 2.72.1
    applied da4096dfb95... glibc: ptest: Fix glibc-tests package issue
    applied 80adcbf1f45... seatd: Disable overflow warning as error on ppc64/musl
    applied ef36e735aea... package.bbclass: Prevent perform_packagecopy from removing /sysroot-only
    applied 6adc3aa634a... kernel-yocto.bbclass: Fixup do_kernel_configcheck usage of KMETA
    applied 9a06759aefc... linux-firmware: correct license for ar3k firmware
    applied 6107518b421... arch-armv8-2a.inc: fix a typo in TUNEVALID variable
    applied 6b96b3c0cc4... musl: Fix build when usrmerge distro feature is enabled
    applied 25a6012a1e5... gcompat: Fix build when usrmerge distro feature is enabled
    applied c5ca6110ce9... wic: do not use PARTLABEL for msdos partition tables
    applied 50d24a763f1... libc-glibc: Use libxcrypt to provide virtual/crypt
    applied 4c098bd8ae4... qemu.bbclass: Extend ppc/ppc64 extra options
    applied 47f2e758372... busybox: Use base_bindir instead of hardcoding /bin path
    applied 42b87970849... gstreamer1.0-plugins-good: Fix libsoup dependency
    applied ce24cf8f2cd... gstreamer1.0: Minor documentation addition
    applied c99977a5170... gstreamer1.0-plugins-bad: drop patch
    applied f8a450a39d4... terminal.py: Restore error output from Terminal
    applied 7f91e5a7d89... devshell.bbclass: Allow devshell & pydevshell to use the network
    applied b11e684951c... cases/buildepoxy.py: fix typo
    applied 04ab58c85d6... create-spdx: delete virtual/kernel dependency to fix FreeRTOS build
    applied 5c91954b7d1... go.bbclass: disable the use of the default configuration file
    applied f6eb7208905... install/devshell: Introduce git intercept script due to fakeroot issues
    applied 5984100237a... base: Drop git intercept
    applied d4a5862ce8d... bitbake.conf: mark all directories as safe for git to read
    applied 6644b3e9b64... neard: Switch SRC_URI to git repo
    applied 646a5903100... sanity: skip make 4.2.1 warning for debian
    applied dfe1dd65e31... util-linux: Create u-a symlink for findfs utility
    applied 5077019ae14... staging: Ensure we filter out ourselves
    applied d84c73d1ef0... libxml2: update patch status
meta-openembedded bb2b5b31a8 -> 5357c7a40e:
    applied 2cd60a50035... crash: Upgrade to 8.0.0
    applied 2acf451b1b6... crash: Fix build for mips target
    applied 0af5a288541... tcsh: Do not install symlinks into /bin with usrmerge
    applied 9d811bf27b3... arno-iptables-firewall: Do not use bitbake variable inside S
    applied 33e7b960882... fluentbit: Fix build with usrmerge distro feature
    applied 6ac64c03764... tomoyo-tools: Define SBINDIR
    applied d2b014de51b... tomoyo-tools: Drop md5sum
    applied f9164cfdd51... dietsplash: specify install rootdir
    applied 594d95b226c... linux-atm: Add knob to root prefix
    applied 84560ca1cde... ufw: Fix build with usrmerge distro feature
    applied 99bf1704236... libldb: Fix installed-vs-shipped and rebuild error
    applied ecaa9057144... klibc: Recognise --dyld-prefix clang option
    applied 00b970a87a6... mozjs: Use vendored icu on ppc/clang
    applied 0105be9ed2f... boinc-client: Do not overwrite same file when using usrmerge
    applied 0d5b77f988a... pam-ssh-agent-auth: Use specific versions of BSD licenses
    applied 1582f81805e... fwupd: Enable build with musl
    applied 828ff23e095... evince: upgrade 42.1 -> 42.2
    applied 7d8535aa304... gspell: upgrade 1.9.1 -> 1.10.0
    applied c6efbc40df8... gtksourceview5: upgrade 5.4.0 -> 5.4.1
    applied 0e49269ea08... libadwaita: upgrade 1.1.0 -> 1.1.1
    applied dc8106d8736... nautilus: upgrade 42.0 -> 42.1.1
    applied f9e26e29611... htpdate: upgrade 1.3.3 -> 1.3.4
    applied af3643de41c... hexedit: upgrade 1.5 -> 1.6
    applied 02a62c79189... lsscsi: upgrade 0.31 -> 0.32
    applied 44affc28fa9... libencode-perl: upgrade 3.16 -> 3.17
    applied 418bd518404... libextutils-cppguess-perl: upgrade 0.23 -> 0.26
    applied cac98ae0ab6... libtest-harness-perl: upgrade 3.42 -> 3.44
    applied 9b7cbd177ee... makedumpfile: Upgrade to 1.7.1
    applied 29a3311dccc... lirc: install systemd units only when using systemd distro feature
    applied f18762a6d13... fluentbit: Disable systemd support when systemd distro feature is disabled
    applied 198e3431176... absil-cpp: Update SRC_URI to to the latest google internal sync
    applied 4efe181cd1a... gtksourceview5: Allow wayland or x11
    applied 2c361302eb2... gtkmm3: Allow wayland or x11 in distro features
    applied cbd06deb96a... gparted: Allow wayland or x11 distro features
    applied 66866c48e3f... lirc: Delete systemd unit files on non systemd distros
    applied ad5424492f4... atkmm: Allow build with wayland
    applied 775b1ebee45... pangomm: Allow building with wayland
    applied e7b312de5b0... pipewire: Upgrade to version 0.3.50
    applied 5357c7a40ea... boinc-client: Make script install not depend on host install paths

openbmc-subtree update -c kirkstone.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
