### PR TITLE
kirkstone: subtree update: 322e9fc9c6 -> cb2a94c39e

### DIFF
--- a/kirkstone.conf
+++ b/kirkstone.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = kirkstone
-last_revision = 5357c7a40eaf8d1bcf7ff58edbba8e9527e40c7d
+last_revision = a47ef046619d639dfbd3be2a13ef6d5b40fd40a1
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -14,11 +14,11 @@ last_revision = 0135a02ea577bd39dd552236ead2c5894d89da1d
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = kirkstone
-last_revision = 93f2146211001ee3cf697d8428969cc3069ed6ba
+last_revision = c79262a30bd385f5dbb009ef8704a1a01644528e
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = kirkstone
-last_revision = d84c73d1ef05b7e12bcab2767f1a1f7a59ad17f2
+last_revision = e4b5c35fd430e1aec8218b4ae4ab51b2b919eec6
 


### PR DESCRIPTION
meta-openembedded 5357c7a40e -> a47ef04661:
    applied 99ae5037e542... meta-oe-image: fix build depends
    applied 49a170035676... frr: inherit autotools-brokensep instead of autotools
    applied 21b475078b9a... conntrack-tools: Fix missing capability
    applied 3a34f2f64177... ufw: Fix packaging errors found with ppc64
    applied 353934eb66fc... libcereal: Enable for glibc/ppc
    applied 802b41d217c0... mimic: Use special rateconv.c license
    applied 35b74d369a37... makedumpfile: Use right TARGET for ppc32
    applied 9f4bdefa4153... evince: Add dbus to depnedencies on non-x11 builds
    applied 947ff549c93c... evolution-data-server: Do not pass --library-path to gir compiler
    applied aebfc98d8931... python3-astroid: upgrade 2.11.2 -> 2.11.3
    applied 204fd35a3d95... meta-python-image: Fix build depends
    applied 94ca1426931e... python3-wxgtk4: Needs x11 for sip module
    applied 26f6e69689b2... meta-gnome: fix layer depends.
    applied f2f81539dc34... networkmanager: fix parallel build failure
    applied 6c63579af1bc... openldap: Remove libgcrypt dependency
    applied fe57c67d29e4... openldap: Upgrade 2.5.9 -> 2.5.12
    applied a6556526d1fb... s-nail: Set VAL_MTA
    applied c8f5b7a278ad... devmem2: reinstate previous patches, removed by mistake
    applied b095a248cc9b... devmem2: add support for different page sizes
    applied 122685c98dfb... devmem2: update SRC_URI according to redirect
    applied 91bcdd0a70e4... vboxguestdrivers: upgrade 6.1.32 -> 6.1.34
    applied 166ef8dbb14a... minidlna: fix obsolete license warning
    applied ab1e20941462... imlib2: update SRC_URI
    applied 797684d24fd9... bats: Add patch to fix false-negatives caused by teardown code
    applied 8c0dca4053df... ostree: prevent ostree-native depending on target virtual/kernel to provide kernel-module-overlay
    applied 3a76ff41af4a... conntrack-tools: fix postinst script
    applied 0b7836265426... bats: upgrade 1.6.0 -> 1.6.1
    applied 6104aead9333... libcamera: fix packaging
    applied 2c051c65a461... jq: Fix typo OE_EXTRACONF -> EXTRA_OECONF
    applied a104444d2bc0... python3-wxgtk4: backport patch to fix svg issue
    applied 7566c789da78... php: upgrade 8.1.4 -> 8.1.5
    applied 71613a9fa18a... php: upgrade 8.1.5 -> 8.1.6
    applied 133d2c20031d... postgresql: upgrade 14.2 -> 14.3
    applied b23cd103136d... sdbus-c++-libsystemd: Bump SRCREV to last commit of 250-stable branch
    applied ff3a018b2b66... libmtp: Add doxygen-native dependency in case documentation build is enabled in PACKAGECONFIG. This fixes a FTBFS due to missing dependency.
    applied 367e8927b9df... mariadb: update to 10.7.4
    applied 4895c4d652b2... mariadb: Fix i386 Clang builds
    applied 442af705f0dc... unattended-upgrades: Disable auto-detecting modules
    applied 79e28d1c8748... libportal: add distro features check
    applied db3a802f8e86... graphviz: rrecommends on liberation-fonts
    applied 16f08eb5aafc... conntrack-tools: fix postinst script
    applied 9a2029553030... sdbus-c++: Link with libatomic on mips/ppc32
    applied 99496d2b3cbe... sdbus-c++: Link with libatomic for rv32
    applied 18a923d20b18... sdbus-c++-libsystemd: Fix patch fuzz
    applied 17da928a8de4... python3-speedtest-cli: fix RDEPENDS
    applied 4e66373fe965... devmem2: the source and patches moved to github repo
    applied fcc7d7eae82b... python3-matplotlib: add missing dependency
    applied caab54d5930a... leveldb: switch from master branch to main
    applied 14023da4dea9... netserver: don't change permissions on /dev/null
    applied 3a019f2b2d67... tesseract-lang: switch from master branch to main
    applied fad4c407c9cb... ntfs-3g-ntfsprogs: Set CVE_PRODUCT to "tuxera:ntfs-3g"
    applied 9c3976adde37... iperf: Set CVE_PRODUCT to "iperf_project:iperf"
    applied 16621ac526d2... python3-pybluez: fix a runtime issue with python 3.10
    applied 18767f177dc6... libgpiod: move test dependencies to ptest package
    applied 3d47772a0121... dnsmasq: Security fix CVE-2022-0934
    applied d7aaee2c377c... chrony: create /var/lib/chrony by systemd-tmpfiles
    applied 7040cffbb06b... networkmanager: fix build with enabled ppp
    applied 6ff027e8d334... exo: upgrade 4.16.3 -> 4.16.4
    applied e4c5f5b3593c... postgresql: upgrade 14.3 -> 14.4
    applied 1cd38eed74a1... strongswan: upgrade 5.9.5 -> 5.9.6
    applied fb7b26b0fb24... fix(syslog-ng): warning about conf version
    applied c455cbab36b4... freeradius: mutlilib fixes
    applied 97375c77128a... emlog: ignore unrelated CVEs
    applied bf2822d59919... dlt-daemon: upgrade to commit 6a3bd901d8 to fix CVE-2022-31291
    applied e5b177aea4e1... cyrus-sasl: CVE-2022-24407 failure to properly escape SQL input allows an attacker to execute arbitrary SQL commands
    applied 1a09e4ffd29a... php: upgrade 8.1.6 -> 8.1.7
    applied 4eaa3091e657... ntfs-3g-ntfsprogs: upgrade to 2022.5.17
    applied 2dd643aa8cdc... imagemagick: upgrade 7.0.10-25 -> 7.0.10-62
    applied 6d1dbf79a0ed... modemmanager: update to 1.18.8
    applied b9bbc38bfba7... protobuf-c: update to 1.4.1 fix CVE-2022-33070
    applied b1091691f8a6... redis: upgrade 6.2.6 -> 6.2.7
    applied ffe6e46314b9... redis: upgrade 7.0-rc3 -> 7.0.2
    applied d1e28ae06915... apache2: upgrade 2.4.53 -> 2.4.54
    applied 0af58eb63d4d... zabbix: upgrade 5.2.6 -> 5.4.12
    applied 9bb44349a596... usrsctp: add CVE_VERSION to correctly check for CVEs
    applied c1e7b0b993c2... openflow: ignore CVE-2018-1078
    applied 743f6e70faaa... ntp: ignore many CVEs
    applied 7e1a69d73d0b... wireshark: upgrade 3.4.11 -> 3.4.12
    applied 5166896a0263... thrift: add CVE_PRODUCT to fix CVE reporting
    applied 66106e15b97a... spice: ignore patched CVEs
    applied b7c6c47d4d5c... quagga: ignore CVE-2016-4049
    applied 4b4c6f4a8a2a... freeradius: ignore patched CVEs
    applied a47ef046619d... openflow: ignore unrelated CVEs
meta-security 93f2146211 -> c79262a30b:
    applied 9301e39d19d6... fscrypt: add distro_check on pam
    applied 8727b7c76a84... aide: Add depend on audit when audit is enabled.
    applied ed75b8866f20... aide: Update 01.17.4
    applied 2f91f348a3a3... tpm2-pkcs11: tpm2-pkcs11 module missing
    applied 4270d36b7510... tpm2-tools: Add missing rdepends
    applied 0325071a1d12... oeqa/cases/tpm2: fix and enhance test suite
    applied b874791a97cc... Parsec-service: Update installation procedure
    applied d3d8e62bf1ca... lib-perl: prefix man pages to avoid conflicting with base perl
    applied 7e3596e848ef... sssd: ignore CVE-2018-16838
    applied ab90048862b7... libmhash: add multilib header
    applied c29ef97c84f0... python3-privacyidea: add correct path to lib/privacyidea
    applied e54e064b9a65... clamav: make install owner match the added user name
    applied c79262a30bd3... meta-integrity: kernel-modsign: prevents splitting out debug symbols
poky d84c73d1ef -> e4b5c35fd4:
    applied a550f8333f9e... bitbake: providers: use local variable for packages_dynamic pattern
    applied 6cb50fc2a116... bitbake: tests/parse: Fix one test overwriting another
    applied e62e1284a04d... bitbake: server/process: Drop unused import
    applied 91cca6ad72c1... bitbake: ui/buildinfohelper: Drop unused import
    applied ba1a9588f06b... bitbake: cooker: Drop unused loop
    applied 2c3009eb3ac7... bitbake: msg: Drop unused local variable
    applied 98472efbcafe... bitbake: buildinfohelper: Drop unused function
    applied 08ee5cf2ea9f... bitbake: fetch2/crate: Drop unused import
    applied 5eb655e42b59... bitbake: siggen: Drop pointless break statement
    applied 1d847bb2cfa0... bitbake: ui/knotty: Drop pointless pass statement
    applied 2de11757c4e6... bitbake: persist_data: Use a valid exception for missing implementation
    applied 455c7b43936b... bitbake: runqueue: Drop pointless variable assignment
    applied 719b4e733be0... bitbake: buildinfohelper: Drop unused variables
    applied b6df0485bc18... bitbake: fetch2/osc: Add missing parameter
    applied b34c2994674e... bitbake: fetch2/ssh.py: decode path back for ssh
    applied dc41a59eaa4b... bitbake: runqueue: Fix sig file location when using multiconfig
    applied fe1a4d124072... bitbake: cache: correctly handle file names containing colons
    applied 0d81d8264559... bitbake: fetch/git : Use cat as pager
    applied 1c65a77b390e... openssl: extract legacy provider module to a separate package
    applied 681ae51e6e72... pulseaudio: conditionally depend on alsa-plugins-pulseaudio-conf
    applied 5e0de3463e8b... kmod: Enable xz support by default
    applied 983c25751762... lib/sstatesig: Fix find_siginfo to match sstate filename generation
    applied 4df837b96f49... go-helloworld: remove unused GO_WORKDIR
    applied 4280a7dd2547... scripts/contrib/oe-build-perf-report-email.py: remove obsolete check for phantomjs and optipng
    applied d19e723ec232... volatile-binds: Change DefaultDependencies from false to no
    applied c0cbd7c572d4... powerpc: Remove invalid GLIBC_EXTRA_OECONF
    applied 02d6a8fd2733... qemu: Add packageconfig for libbpf support
    applied 14d4c5559284... linux-yocto/5.10: update to v5.10.110
    applied 086152f28606... linux-yocto/5.10: base: enable kernel crypto userspace API
    applied bd83f437b22e... linux-yocto/5.10: update to v5.10.112
    applied 3b78842c32fd... poky-tiny: enable qemuarmv5/qemuarm64 and cleanups
    applied c115a5d6c9da... linux-yocto/5.15: arm: poky-tiny cleanup and fixes
    applied 635c41473775... linux-yocto/5.15: update to v5.15.33
    applied f31412cd99b0... linux-yocto/5.15: base: enable kernel crypto userspace API
    applied 74dbe8d87896... linux-yocto/5.15: kasan: fix BUG: sleeping function called from invalid context
    applied 304e8e24961c... linux-yocto/5.15: fix ppc boot
    applied dd1d4a5f7025... linux-yocto/5.15: netfilter: conntrack: avoid useless indirection during conntrack destruction
    applied b6bc88c36524... linux-yocto/5.15: update to v5.15.35
    applied c9896633c240... linux-yocto/5.15: Fix CVE-2022-28796
    applied eccb29aba006... linux-yocto: enable powerpc debug fragment
    applied f6ebb5822506... linux-yocto/5.15: fix -standard kernel build issue
    applied e50b978409da... linux-yocto/5.15: update to v5.15.36
    applied 533d5ae8c41a... linux-yocto: Enable powerpc-debug fragment for ppc64 LE
    applied 17fe9070f9ee... linux-yocto/5.15: fix qemuarm graphical boot
    applied b1a9c64d5d83... strace: fix ptest failure in landlock
    applied e163bed574a9... cve-check: no need to depend on the fetch task
    applied fc56536e8ad4... cve-update-db-native: update the CVE database once a day only
    applied b7601c92ffff... cve-update-db-native: let the user to drive the update interval
    applied 645c157befa8... cve-check: add JSON format to summary output
    applied dd08692cac01... cve-check: fix symlinks where link and output path are equal
    applied c5580a0571e3... rootfs-postcommands: fix symlinks where link and output path are equal
    applied 6c843a506909... oeqa/selftest: add test for git working correctly inside pseudo
    applied 74522a6048c9... base: Avoid circular references to our own scripts
    applied db10b2623d58... scripts: Make git intercept global
    applied 7868ccd57ab1... scripts/git: Ensure we don't have circular references
    applied 38c8316155fc... Revert "bitbake.conf: mark all directories as safe for git to read"
    applied 667ea364293a... package: Ensure we track whether PRSERV was active or not
    applied ca27d0e61340... abi_version/sstate: Bump hashequiv and sstate versions due to git changes
    applied 5bac84e95429... yocto-bsps: update to v5.15.36
    applied 300cc188719e... poky.conf: bump version for 4.0.1 release
    applied 8941afebd183... qemuarmv5: use arm-versatile-926ejs KMACHINE
    applied 546d7cfea4f6... virgl: skip headless test on alma 8.6
    applied 93491db3bfe9... openssl: minor security upgrade 3.0.2 -> 3.0.3
    applied 8c489602f218... build-appliance-image: Update to kirkstone head revision
    applied 7f44415639d8... freetype: backport patch for CVE-2022-27404
    applied c27fdfb8510c... freetype: backport patch for CVE-2022-27405
    applied cf9a7e4cc66f... freetype: backport patch for CVE-2022-27406
    applied d6e618ac2e09... qemu: backport patch for CVE-2021-4206
    applied e977c0cf23fc... qemu: backport patch for CVE-2021-4207
    applied 72f4f94d4ede... systemd: upgrade 250.4 -> 250.5
    applied 226c321269a1... systemd: Fix build regression with latest update
    applied 1b98b1901787... mesa: upgrade 22.0.0 -> 22.0.2
    applied ef9819dfb126... bind: upgrade 9.18.1 -> 9.18.2
    applied 6648bf972f15... cronie: upgrade 1.6.0 -> 1.6.1
    applied c8e81c00a9aa... epiphany: upgrade 42.0 -> 42.2
    applied 9bbf4f6ddbcc... ffmpeg: upgrade 5.0 -> 5.0.1
    applied 713dea485fcc... fribidi: upgrade 1.0.11 -> 1.0.12
    applied f5b41e718199... libinput: upgrade 1.19.3 -> 1.19.4
    applied 2b7d34e5ec21... sqlite3: upgrade 3.38.2 -> 3.38.3
    applied 7fb8cfd96c2f... webkitgtk: upgrade 2.36.0 -> 2.36.1
    applied 21da7a4def8f... xwayland: upgrade 22.1.0 -> 22.1.1
    applied 708d0151242e... libxml2: Upgrade 2.9.13 -> 2.9.14
    applied 0070210dee83... vim: Upgrade 8.2.4681 -> 8.2.4912
    applied 98481ac1de15... linux-firmware: replace mkdir by install
    applied eedfa5ace389... linux-firmware: upgrade 20220411 -> 20220509
    applied 718700b20e08... cairo: Add missing GPLv3 license checksum entry
    applied 524a41059d77... pypi.bbclass: Set CVE_PRODUCT to PYPI_PACKAGE
    applied a8a094e5118e... wic/plugins/rootfs: Fix permissions when splitting rootfs folders across partitions
    applied 0c68e5f59967... e2fsprogs: update upstream status
    applied 0af576a3b0f6... overlayfs: add docs about skipping QA check & service dependencies
    applied 3009af101b10... image.bbclass: allow overriding dependency on virtual/kernel:do_deploy
    applied c4668d6424fd... sanity: Don't warn about make 4.2.1 for mint
    applied d7f2bec47aa1... sed: Specify shell for "nobody" user in run-ptest
    applied 51e3b634277b... strace: Don't run ptest as "nobody"
    applied 453be4d258f7... base-passwd: Disable shell for default users
    applied 7c0dd56d2819... bitbake: fetch2/osc: Small fixes for osc fetcher
    applied 2fd92929c2f7... bitbake: data: Do not depend on vardepvalueexclude flag
    applied 03cc5f63bc89... bitbake: build: Add clean_stamp API function to allow removal of task stamps
    applied ee8d859d053b... curl: Backport CVE fixes
    applied 31909cc347fc... cve-check: Fix report generation
    applied d691ddf6ad95... python3: fix reproducibility issue with python3-core
    applied fbbbd289b641... mmc-utils: upgrade to latest revision
    applied 4f32541b2d3b... librepo: upgrade 1.14.2 -> 1.14.3
    applied cf6699a5cbff... binutils: Bump to latest 2.38 release branch
    applied ec7da0e06802... classes: rootfs-postcommands: add skip option to overlayfs_qa_check
    applied 2c363c233324... staging: Fix rare sysroot corruption issue
    applied 8d27f1fea95b... selftest/imagefeatures/overlayfs: Always append to DISTRO_FEATURES
    applied ce9e354ebdde... pcre2: CVE-2022-1586 Out-of-bounds read
    applied b2e5a0b9cbcd... oeqa/selftest/cve_check: add tests for recipe and image reports
    applied 54a7fff2f5b7... go: upgrade 1.17.8 -> 1.17.10
    applied cf49b3984a37... gst-devtools: upgrade 1.20.1 -> 1.20.2
    applied 9f8aea1017f0... gstreamer1.0-libav: upgrade 1.20.1 -> 1.20.2
    applied 84992519289e... gstreamer1.0-omx: upgrade 1.20.1 -> 1.20.2
    applied ce55294b635c... gstreamer1.0-plugins-bad: upgrade 1.20.1 -> 1.20.2
    applied b2ba5f738afa... gstreamer1.0-plugins-base: upgrade 1.20.1 -> 1.20.2
    applied 46030ac6c8e5... gstreamer1.0-plugins-good: upgrade 1.20.1 -> 1.20.2
    applied e2a382ffc13d... gstreamer1.0-plugins-ugly: upgrade 1.20.1 -> 1.20.2
    applied 3951888a0936... gstreamer1.0-python: upgrade 1.20.1 -> 1.20.2
    applied 4c4b14f0da1f... gstreamer1.0-rtsp-server: upgrade 1.20.1 -> 1.20.2
    applied 7660a5d019b9... gstreamer1.0: upgrade 1.20.1 -> 1.20.2
    applied e3de9ae200cc... gstreamer1.0-vaapi: upgrade 1.20.1 -> 1.20.2
    applied ddec31a80135... libcgroup: upgrade 2.0.1 -> 2.0.2
    applied 74db0dc42887... mesa: upgrade 22.0.2 -> 22.0.3
    applied f38c8c7ad076... mobile-broadband-provider-info: upgrade 20220315 -> 20220511
    applied 354e77870916... sqlite3: upgrade 3.38.3 -> 3.38.5
    applied 269f457a62b4... license_image.bbclass: Make QA errors fail the build
    applied 00c04394cbc5... tiff: mark CVE-2022-1622 and CVE-2022-1623 as invalid
    applied fd6b78f90cf5... vim: Upgrade 8.2.4912 -> 8.2.5034 to fix 9 CVEs
    applied 4a13afb27ea3... tiff: Add jbig PACKAGECONFIG and clarify CVE-2022-1210
    applied 01e54e3b62c1... libxslt: Mark CVE-2022-29824 as not applying
    applied edf2b57a6b3b... cve-check.bbclass: Added do_populate_sdk[recrdeptask].
    applied ecac8cb4f7a6... cve-check: Add helper for symlink handling
    applied e72a86859396... cve-check: Only include installed packages for rootfs manifest
    applied 5ab5cedbc553... cve-extra-exclusions: Add kernel CVEs
    applied cd12e92aabb3... cve-check: Allow warnings to be disabled
    applied 3dc0acd18fdb... linux-yocto/5.15: update to v5.15.37
    applied 3cd1e83f9bc4... linux-yocto/5.10: update to v5.10.113
    applied d0f237a311c2... linux-yocto/5.15: update to v5.15.38
    applied d1b92a322a8b... linux-yocto/5.10: update to v5.10.114
    applied 8de0650a97e0... libpcre2: upgrade 10.39 -> 10.40
    applied e13ce12e4ad7... ncurses: update to patchlevel 20220423
    applied 1ec2bdeff64f... mesa.inc: package 00-radv-defaults.conf
    applied 57e088cfe35c... staging.bbclass: process direct dependencies in deterministic order
    applied 9437dc278354... libseccomp: Add missing files for ptests
    applied 87d7e9d70365... insane.bbclass: make sure to close .patch files
    applied c9b490e16211... pciutils: avoid lspci conflict with busybox
    applied cd23b8349e8b... ovmf: Fix native build with gcc-12
    applied 8286eaeff179... rust-common: Fix sstate signatures between arm hf and non-hf
    applied a394d454f8c4... rust-common: Ensure sstate signatures have correct dependencues for do_rust_gen_targets
    applied a0d3dde7c0fb... rust-common: Fix for target definitions returning 'NoneType' for arm
    applied 4e05a1761611... rust-common: Drop LLVM_TARGET and simplify
    applied c29718ee73be... rust-common: Fix native signature dependency issues
    applied 45d7615dfef8... gcc: Upgrade to 11.3 release
    applied 48713ac1c39a... systemd: Drop redundant musl patches
    applied 5a316a07e2f4... systemd: Document future actions needed for set of musl patches
    applied 6cd66bd9fba4... systemd: Drop 0016-Hide-__start_BUS_ERROR_MAP-and-__stop_BUS_ERROR_MAP.patch
    applied 3a8430281d23... systemd: Update patch status
    applied 94095275b5be... systemd: Drop 0001-test-parse-argument-Include-signal.h.patch
    applied 4c3f51142b4a... systemd: Remove __compare_fn_t type in musl-specific patch
    applied fc3f32670625... systemd: Drop 0002-don-t-use-glibc-specific-qsort_r.patch
    applied 09007ea722ef... systemd: Correct path returned in sd_path_lookup()
    applied b0791dc9fa07... bash: submit patch upstream
    applied 339af910c395... valgrind: submit arm patches upstream
    applied 6ef864a43e5c... makedevs: Don't use COPYING.patch just to add license file into ${S}
    applied 6709d49f1e51... zip/unzip: mark all submittable patches as Inactive-Upstream
    applied 2d031b7e2ab9... lzo: Add further info to a patch and mark as Inactive-Upstream
    applied 7f22fb48eb91... cve-check: move update_symlinks to a library
    applied 34eecaa053b2... cve-check: write empty fragment files in the text mode
    applied 50ee11d88fb0... cve-check: fix return type in check_cves
    applied 9661c7eb0766... cve-update-db-native: make it possible to disable database updates
    applied 42db1a907293... cups: upgrade 2.4.1 -> 2.4.2
    applied 8c9ea9f6b9cd... logrotate: upgrade 3.19.0 -> 3.20.1
    applied fa2e8b818392... glib-2.0: upgrade 2.72.1 -> 2.72.2
    applied c09b41fb91ce... libxkbcommon: upgrade 1.4.0 -> 1.4.1
    applied ca619ca25b1b... gtk+3: upgrade 3.24.33 -> 3.24.34
    applied ba399cc6ba4a... webkitgtk: upgrade 2.36.1 -> 2.36.3
    applied 7e7dca984423... linux-firmware: package new Qualcomm firmware
    applied 6a5e26dad556... linux-firmware: split ath3k firmware
    applied 411fbde5acb1... patch.py: make sure that patches/series file exists before quilt pop
    applied da9e2bb83675... openssl: Backport fix for ptest cert expiry
    applied 94ea8b846155... gcc: depend on zstd-native
    applied 8c33c7efbecb... gcc-cross-canadian: Add nativesdk-zstd dependency
    applied a4ee07275cc3... perl: Fix build with gcc-12
    applied bced754b565c... kernel-yocto.bbclass: Reset to exiting on non-zero return code at end of task
    applied ece8d4cfcb4c... alsa-plugins: fix libavtp vs. avtp packageconfig
    applied 5c04e06d768b... libseccomp: Correct LIC_FILES_CHKSUM
    applied a04b59c40b38... license.bbclass: Bound beginline and endline in copy_license_files()
    applied 6c5137920640... rootfs.py: find .ko.zst kernel modules
    applied d87cbd6f16c2... local.conf.sample: Update sstate url to new 'all' path
    applied 068aad9f1d59... sanity: Switch to make 4.0 as a minimum version
    applied c9cf0084c4b7... perl: Add dependency on make-native to avoid race issues
    applied 8e447284207c... glibc: Drop make-native dependency
    applied ff7a7dec9bde... bitbake.conf: Make TCLIBC and TCMODE lazy assigned
    applied ef1df297f153... baremetal-image: fix broken symlink in do_rootfs
    applied cf73ba2e314a... iso-codes: upgrade 4.9.0 -> 4.10.0
    applied 001a2245cf85... lttng-ust: upgrade 2.13.2 -> 2.13.3
    applied b23a467255ad... linux-yocto/5.15: bpf: explicitly disable unpriv eBPF by default
    applied c5371ad452bc... linux-yocto/5.15: update to v5.15.43
    applied 7706f5ac7702... linux-yocto/5.10: update to v5.10.118
    applied cc852b651e53... linux-yocto/5.15: Enable MDIO bus config
    applied e939a933d3c5... linux-yocto/5.15: cfg/xen: Move x86 configs to separate file
    applied eacca888d492... linux-yocto/5.15: update to v5.15.44
    applied 57962911f2a0... linux-yocto/5.10: update to v5.10.119
    applied 7cdf493ae75f... lttng-modules: fix build against 5.18-rc7+
    applied aa01d3f0f7e6... lttng-modules: Fix build failure for 5.10.119+ and 5.15.44+ kernel
    applied ccb4acab4401... lttng-modules: fix shell syntax
    applied ccd816b8654f... systemd: Correct 0001-pass-correct-parameters-to-getdents64.patch
    applied 70fabbb2d05c... buildhistory.bbclass: fix shell syntax when using dash
    applied 4aeda14352a9... rootfs.py: close kernel_abi_ver_file
    applied a6344dc61af4... vim: Upgrade 8.2.5034 -> 8.2.5083
    applied 60774248a557... uboot-sign: Fix potential index error issues
    applied e6617042c1eb... selftest/multiconfig: Test that multiconfigs in separate layers works
    applied 38f2a7717646... devtool: Fix _copy_file() TypeError
    applied 16edf84ea8df... meson.bbclass: add cython binary to cross/native toolchain config
    applied c56f8142a16d... archiver: use bb.note instead of echo
    applied 62fdfa45ab69... xxhash: fix build with gcc 12
    applied cb1444e7bd03... oescripts: change compare logic in OEListPackageconfigTests
    applied 1cc03505ce37... e2fsprogs: add alternatives handling of lsattr as well
    applied d37d6ad96015... popt: fix override syntax in RDEPENDS
    applied 53e89f549977... git: fix override syntax in RDEPENDS
    applied 7139d8d63b8f... gcc-source: Fix incorrect task dependencies from ${B}
    applied 9cfff7329a06... archiver: don't use machine variables in shared recipes
    applied 93e32bf474fc... systemd: update 0008-add-missing-FTW_-macros-for-musl.patch
    applied 0c3b92901ced... liberror-perl: Update sstate/equiv versions to clean cache
    applied c086c4b35aa6... cve-check: add support for Ignored CVEs
    applied 4c7c68450714... oeqa/selftest/cve_check: add tests for Ignored and partial reports
    applied b7e0663ddea1... linux-firmware: add support for building snapshots
    applied dea39dd27ea9... linux-firmware: upgrade 20220509 -> 20220610
    applied 88c069b8bf64... python3: use built-in distutils for ptest, rather than setuptools' 'fork'
    applied d841c3524b2b... python3: Remove problematic paths from sysroot files
    applied daa47a61714a... python3: Ensure stale empty python module directories don't break the build
    applied 141de70a3990... python: Avoid shebang overflow on python-config.py
    applied 284cd917f875... efivar: add musl libc compatibility
    applied e056477ce09c... systemd: systemd-systemctl: Support instance conf files during enable
    applied 85856cea84b9... gtk-doc: Fix potential shebang overflow on gtkdoc-mkhtml2
    applied 460dd9529dbc... rootfs-postcommands.bbclass: correct comments
    applied 467964601aad... mesa: backport a patch to support compositors without zwp_linux_dmabuf_v1 again
    applied 759a3eb9b585... bitbake: server/process: Fix logging issues where only the first message was displayed
    applied c00f584817d2... manuals: switch to the sstate mirror shared between all versions
    applied 213f174999a1... poky.conf: bump version for 4.0.2
    applied a5ea426b1da4... build-appliance-image: Update to kirkstone head revision
    applied 6ca152967b20... unzip: Port debian fixes for two CVEs
    applied 0a954bf5d7cf... ghostscript: fix CVE-2022-2085
    applied 2a59abcb909e... binutils : CVE-2019-1010204
    applied fcfda2b40e2e... cups: ignore CVE-2022-26691
    applied 0014fd43f31a... busybox: fix CVE-2022-30065
    applied e6116b7ae0cb... cve-extra-exclusions: Clean up and ignore three CVEs (2xqemu and nasm)
    applied 611d7ed2acc8... cve-check: hook cleanup to the BuildCompleted event, not CookerExit
    applied 231e6f67728c... wireless-regdb: upgrade 2022.04.08 -> 2022.06.06
    applied ac087037fe92... vim: 8.2.5083 -> 9.0.0005
    applied 327f55e29811... openssl: Upgrade 3.0.3 -> 3.0.4
    applied ac874996c96d... initramfs-framework: move storage mounts to actual rootfs
    applied cc75d77bc930... libffi: fix native build being not portable
    applied 2fd4a2008870... wic: fix WicError message
    applied a6987c6eb1bb... perf: sort-pmuevents: really keep array terminators
    applied 9ef7d8daad18... kernel-uboot.bbclass: Use vmlinux.initramfs when INITRAMFS_IMAGE_BUNDLE set
    applied 5ef41c8eb0d1... insane.bbclass: host-user-contaminated: Correct per package home path
    applied 2fa6cb826f56... sanity.bbclass: Add ftps to accepted URI protocols for mirrors sanity
    applied ec6149d0002b... oeqa/sdk: drop the nativesdk-python 2.x test
    applied 20646e140cc9... base.bbclass: Correct the test for obsolete license exceptions
    applied 8ef42d553296... coreutils: Tweak packaging variable names for coreutils-dev
    applied a224001daa15... at: take tarballs from debian
    applied b2dba5ca25a7... rust: fix issue building cross-canadian tools for aarch64 on x86_64
    applied 0b047cb6e70e... recipetool/devtool: Fix python egg whitespace issues in PACKAGECONFIG
    applied cacf2eac3da1... glibc-tests: not clear BBCLASSEXTEND
    applied 91df5c1c7bcc... curl: backport openssl fix CN check error code
    applied 7766d5465166... oeqa/runtime/scp: Disable scp test for dropbear
    applied 1d537a6d6348... packagegroup-core-ssh-dropbear: Add openssh-sftp-server recommendation
    applied af092f2d1267... oe-selftest-image: Ensure the image has sftp as well as dropbear
    applied 523a19e0b025... openssh: break dependency on base package for -dev package
    applied 88fe015a6314... dropbear: break dependency on base package for -dev package
    applied b444cac69ed9... ruby: add PACKAGECONFIG for capstone
    applied 073c1432a099... qemu: add PACKAGECONFIG for capstone
    applied 85eb363d3a02... qemu: Avoid accidental librdmacm linkage
    applied b7a414eaf02c... qemu: Avoid accidental libvdeplug linkage
    applied 917569e54b6a... harfbuzz: fix CVE-2022-33068
    applied 39e1584719b2... tiff: backport the fix for CVE-2022-2056, CVE-2022-2057, and CVE-2022-2058
    applied 10554d45a533... u-boot: fix CVE-2022-34835
    applied 97e48b17b92f... vim: upgrade to 9.0.0021
    applied 07d4a34af090... openssl: update 3.0.4 -> 3.0.5
    applied 652801de5487... glibc: stable 2.35 branch updates
    applied c0b6724170e9... glibc-tests: Avoid reproducibility issues
    applied ff1b9910c863... binutils : stable 2.38 branch updates
    applied 7f7a89a57395... gstreamer1.0: upgrade 1.20.2 -> 1.20.3
    applied 3bbefb5b76bc... gst-devtools: upgrade 1.20.2 -> 1.20.3
    applied ccaf9222e5a4... gstreamer1.0-libav: upgrade 1.20.2 -> 1.20.3
    applied b23fb8bc9157... gstreamer1.0-omx: upgrade 1.20.2 -> 1.20.3
    applied f6e2a22000cf... gstreamer1.0-plugins-bad: upgrade 1.20.2 -> 1.20.3
    applied d4d14e04ba6c... gstreamer1.0-plugins-base: upgrade 1.20.2 -> 1.20.3
    applied ac40ccb37890... gstreamer1.0-plugins-good: upgrade 1.20.2 -> 1.20.3
    applied b2327c81d992... gstreamer1.0-plugins-ugly: upgrade 1.20.2 -> 1.20.3
    applied 90ab0b6a5e81... gstreamer1.0-python: upgrade 1.20.2 -> 1.20.3
    applied c7fee3136b92... gstreamer1.0-rtsp-server: upgrade 1.20.2 -> 1.20.3
    applied 3e70a9cbb0cf... gstreamer1.0-vaapi: upgrade 1.20.2 -> 1.20.3
    applied 742176bf5d26... weston: update 10.0.0 -> 10.0.1
    applied fae45052cfda... glib-2.0: upgrade 2.72.2 -> 2.72.3
    applied 46378a82edf7... glib-networking: upgrade 2.72.0 -> 2.72.1
    applied e8af53db951f... libsoup: upgrade 3.0.6 -> 3.0.7
    applied b373ad840507... docs: BB_HASHSERVE_UPSTREAM: update to new host
    applied 236f30b8a9cb... ref-manual: variables: remove sphinx directive from literal block
    applied 6d48a8cd43ea... qemu: Fix slirp determinism issue
    applied d7006757c05c... qemu: Add PACKAGECONFIG for brlapi
    applied 04cab26956b3... linux-yocto/5.10: update to v5.10.121
    applied d20597c2763d... linux-yocto/5.10: update to v5.10.123
    applied 2ff94a99d678... linux-yocto/5.10: update to v5.10.128
    applied f4b26272a898... linux-yocto/5.10: fix build_OID_registry/conmakehash buildpaths warning
    applied b16abf35d01f... linux-yocto/5.10: fix buildpaths issue with gen-mach-types
    applied bdfdd75540d3... linux-yocto/5.10: update to v5.10.130
    applied 9f0809cf27a5... linux-yocto/5.10: fix buildpaths issue with pnmtologo
    applied feb63e3c9f1f... linux-yocto/5.15: update to v5.15.46
    applied bf95167f7a62... linux-yocto/5.15: update to v5.15.48
    applied 869134924a97... linux-yocto/5.15: drop obselete GPIO sysfs ABI
    applied 8bed8f42849e... linux-yocto/5.15: update to v5.15.52
    applied a706523d4110... linux-yocto/5.15: fix qemuppc buildpaths warning
    applied c3f8a6f93b16... linux-yocto/5.15: fix build_OID_registry buildpaths warning
    applied a3b94334e9f7... linux-yocto/5.15: fix buildpaths issue with gen-mach-types
    applied ada3d3741ae7... linux-yocto/5.15: update to v5.15.54
    applied 083616689f02... linux-yocto/5.15: fix buildpaths issue with pnmtologo
    applied 3e6f03797c3b... kernel-devsrc: fix reproducibility and buildpaths QA warning
    applied 1c8f219ec6ba... kernel-devsrc: ppc32: fix reproducibility
    applied eaa86c868174... gperf: Add a patch to work around reproducibility issues
    applied dd826b85aef2... gperf: Switch to upstream patch
    applied 1db72445e39e... perf: fix reproducibility in 5.19+
    applied 702cf1e964f0... curl: Fix multiple CVEs
    applied c82f38999b51... harfbuzz: Fix compilation with clang
    applied f884ab8ffcb3... udev-extraconf/initrdscripts/parted: Rename mount.blacklist -> mount.ignorelist
    applied 88bc9d2b93de... udev-extraconf: let automount base directory configurable
    applied 2d0aed6469d9... udev-extraconf/mount.sh: add LABELs to mountpoints
    applied 40af8a94d881... udev-extraconf/mount.sh: save mount name in our tmp filecache
    applied 8eafba72be11... udev-extraconf/mount.sh: only mount devices on hotplug
    applied c993a88c3fa7... udev-extraconf: force systemd-udevd to use shared MountFlags
    applied a19f966ef5a4... udev-extraconf/mount.sh: ignore lvm in automount
    applied 342745ce67da... udev-extraconf: fix some systemd automount issues
    applied 66f67f397e1b... udev-extraconf:mount.sh: fix path mismatching issues
    applied 8fa95bb5991e... python3: Backport patch to fix an issue in subinterpreters
    applied 195b61756bae... package.bbclass: Fix base directory for debugsource files when using externalsrc
    applied f1d0a3c7c6c6... package.bbclass: Avoid stripping signed kernel modules in splitdebuginfo
    applied 4fd8f9b863ff... package.bbclass: Fix kernel source handling when not using externalsrc
    applied bf3232255d5a... insane: Fix buildpaths test to work with special devices
    applied 5b4699fc90e2... waffle: correctly request wayland-scanner executable
    applied d9f2186c1e5b... lua: Fix multilib buildpath reproducibility issues
    applied 6ad0dc29c475... vala: Fix on target wrapper buildpaths issue
    applied 78b9ca277cef... libmodule-build-perl: Use env utility to find perl interpreter
    applied 9489baf01155... gtk-doc: Remove hardcoded buildpath
    applied ae5fb5a00dc9... perl: don't install Makefile.old into perl-ptest
    applied 4006a03674ac... alsa-state: correct license
    applied a21c4df12fa3... kernel-arch: Fix buildpaths leaking into external module compiles
    applied de0d04dfa3ea... devtool: ignore pn- overrides when determining SRC_URI overrides
    applied dd1fac1e1150... bin_package: install into base_prefix
    applied 9e7a56bef763... patch: handle if S points to a subdirectory of a git repo
    applied ee60960da3ba... devtool: finish: handle patching when S points to subdir of a git repo
    applied eabdc02b763c... oe-selftest: devtool: test modify git recipe building from a subdir
    applied 3af7f4ba996a... gcc-runtime: Fix build when using gold
    applied 17421c1fe2ea... gcc-runtime: Fix missing MLPREFIX in debug mappings
    applied 0d806a3af4fa... selftest/runtime_test/virgl: Disable for all almalinux
    applied 2355f5dc1e4f... cargo_common.bbclass: enable bitbake vendoring for externalsrc
    applied 4146e3c6a85f... externalsrc.bbclass: support crate fetcher on externalsrc
    applied e4b5c35fd430... pulseaudio: add m4-native to DEPENDS

openbmc-subtree update -c kirkstone.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
