### PR TITLE
subtree update: 7886cd74f9 -> e43e41c87e

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 80d60e7b1cbe50bb22ce26956d22635ec51cc7f4
+last_revision = 20a629180ca3a15ea8687b3bdaf8c7cda8b42bbb
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 31c10bd3e6792da2d439cc9e72862d7cb63cf34a
+last_revision = 2eb39477a784673baefa59640909b827ebb689b2
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 62a84833d90dfc18f8057bc5e99e96eff6798f12
+last_revision = b6a1645a97d2de7f08f7d37c7a8f2991ab45032d
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 7ad5f6a9da1b5a55699d5b8e7ad80476ad5a4695
+last_revision = 2a2d650ee03af904d35c06134731b96b0feb2b60
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 4161dbbbd6c446501b6ec750f5dbc7fb0296eac0
+last_revision = fc59c287247b5b4d2c0266d72a2b2830dc6e1ef8
 


### PR DESCRIPTION
meta-raspberrypi 62a84833d9 -> b6a1645a97:
    applied 260b3b97d001... ci: Migrate worflow to using latest git-mirror-me-action revision
    applied 1a15fefb2708... ci: Run the cancel workflow on generic workers and update action
    applied 584785bf45cb... ci: Run the compliance workflow on generic workers
    applied 05cafd056aef... ci: Run the mirror workflow on generic workers
    applied 70191d3c871c... ci: Don't run yocto builds on PRs that don't affect them
    applied 3337b532eb86... docs: remove backticks
    applied 4ede22cb679b... raspberrypi-tools.inc: Bump to latest revision
    applied 356c0afee954... rpi-gpio: Bump to 0.7.1
    applied 444f83221c92... python3-adafruit-platformdetect: Bump to 3.27.0
    applied a087707b1fc2... python3-adafruit-circuitpython-register: Bump to 1.9.10
    applied 38776890b7b4... userland: Bump revision to the current HEAD
    applied 18a11f59b88f... bluez-firmware-rpidistro: Backport patch to fix CYW43455 and various CVEs
    applied 73142a23e453... linux-raspberrypi: Update 5.15 recipe to 5.15.56
    applied 8f8b8c9fee81... linux-raspberrypi: Update 5.10 recipe to latest revision
    applied 263920a672cc... linux-firmware-rpidistro: Update to 1:20210315-3+rpt7 release
    applied 3122d5291da5... omxplayer: Bump to latest revision
    applied 1b4215d5d0bf... linux-firmware-rpidistro: Revamp, cleanup and restructure recipe
    applied 7c31b9b4b595... linux-firmware-rpidistro: Guard the recipe under a license flag
    applied 0ffe5110ec83... ci: Set LICENSE_FLAGS_ACCEPTED in builder docker container
    applied d9ea8f66d9fd... README.md: Mention Yocto Compatible Layer
    applied 3bef4f04cc86... README.md: Refactor top table
    applied 9a65a5cc1892... Add initial version of CODE_OF_CONDUCT.md
    applied b6a1645a97d2... Use a png with transparency for balena logo
poky 4161dbbbd6 -> fc59c28724:
    applied 706975657227... curl: Fix determinism issues in ptest package
    applied 1a3aaa47b161... pulseaudio: add m4-native to DEPENDS
    applied 9a528bd5bd6f... package.bbclass: Fix kernel source handling when not using externalsrc
    applied 7e6fed6af77a... conf/local.conf.sample: mention site.conf.sample as well
    applied 832fb7c1c3ed... lua: Backport fix for CVE-2022-33099
    applied 2d1838b7bc4c... python3-picobuild: upgrade to 0.2
    applied 2ebe1001840f... python3-docutils: upgrade 0.18.1 -> 0.19
    applied f414763fa0fb... sstatesig: Include all dependencies in SPDX task signatures
    applied b53880d3400b... rootfs-postcommands.bbclass: move host-user-contaminated.txt to ${S}
    applied 476a89a436a5... kernel-fitimage.bbclass: add padding algorithm property in config nodes
    applied 957e82e19b25... python3-jsonschema: 4.7.1 -> 4.7.2 + fixed the rdepends
    applied 704a7a86810e... gobject-introspection-data: Disable cache for g-ir-scanner
    applied 093398daf500... bitbake: bitbake: bitbake-user-manual: hashserv can be accessed on a dedicated domain
    applied 899979696f68... build-appliance-image: Update to master head revision
    applied 815202557280... ref-manual: Sphinx note directive for DISTRO_FEATURES definition
    applied 8db83d989d13... migration guides: release notes for 4.0.2
    applied 102278a77f01... docs: ref-manual: variables: remove sphinx directive from literal block
    applied 9926c0bf2f27... docs: auto-generate releases.rst
    applied 1127e9a7b850... docs: BB_HASHSERVE_UPSTREAM: update to new host
    applied 33ff9b7d139c... oeqa/runtime: add test that the kernel has CONFIG_PREEMPT_RT enabled
    applied 23d8501adcc6... bitbake: asyncrpc: Add TCP Keep Alives
    applied 2642bdb8908a... gcc-runtime: Pass -nostartfiles when building dummy libstdc++.so
    applied 6ed3e6325a69... dropbear: Add configuration file to CONFFILES
    applied 095787655d72... wic/plugins/rootfs: Fix NameError for 'orig_path'
    applied e4da038708d0... systemd: Added base_bindir into pkg_postinst:udev-hwdb.
    applied beeb6e95e566... sato-icon-theme: check for new commits rather than tags
    applied 3fa18ba264ef... gcr: exclude x.9y versions from upstream version check
    applied 157db777fcf2... efibootmgr: update 17 -> 18
    applied 39a488e332b8... systemd-boot: update 251.2 -> 251.3
    applied 22c19f861199... libva: upgrade 2.14.0 -> 2.15.0
    applied d4b7efbb5886... libva-utils: update 2.14.0 -> 2.15.0
    applied 601b482f6d24... xev: update 1.2.4 -> 1.2.5
    applied 5464c3b5e909... xmodmap: update 1.0.10 -> 1.0.11
    applied f1f898004f61... xf86-input-synaptics: update 1.9.1 -> 1.9.2
    applied f3a389a6d752... xf86-video-cirrus: update 1.5.3 -> 1.6.0
    applied abc7d95ab52f... encodings: update 1.0.5 -> 1.0.6
    applied 56ee40a9e316... font-util: update 1.3.2 -> 1.3.3
    applied cbb6042427f8... linux-firmware: update 20220610 -> 20220708
    applied af08e28f0187... rt-tests: update 2.3 -> 2.4
    applied 275aae67feba... libgit2: update 1.4.3 -> 1.5.0
    applied 96f645e4d284... u-boot: update 2022.04 -> 2022.07
    applied 6963b041bc35... go: update 1.18.3 -> 1.18.4
    applied 0a060f338c99... llvm: update 14.0.4 -> 14.0.6
    applied ca282da0b8b2... vulkan-samples: update to latest revision
    applied 9b68b63b6c6a... xserver-xorg: update 21.1.3 -> 21.1.4
    applied baa1241c4968... alsa-lib: upgrade 1.2.7.1 -> 1.2.7.2
    applied 44dec427d6a3... alsa-ucm-conf: upgrade 1.2.7.1 -> 1.2.7.2
    applied e1ebf1cd25b3... diffoscope: upgrade 217 -> 218
    applied bd7dd3e50941... git: upgrade 2.37.0 -> 2.37.1
    applied 93a49d70c80d... hdparm: upgrade 9.63 -> 9.64
    applied fe79ad111957... libdrm: upgrade 2.4.111 -> 2.4.112
    applied e5ed0387b0c6... libhandy: upgrade 1.6.2 -> 1.6.3
    applied e614dab6d822... libidn2: upgrade 2.3.2 -> 2.3.3
    applied fffce97a93f9... libnl: upgrade 3.6.0 -> 3.7.0
    applied 70b23060111d... libnotify: upgrade 0.7.12 -> 0.8.0
    applied eaf011b55e4d... libuv: upgrade 1.44.1 -> 1.44.2
    applied 13cac725dbf0... log4cplus: upgrade 2.0.7 -> 2.0.8
    applied 5a3bb4b4a46c... meson: upgrade 0.62.2 -> 0.63.0
    applied 7dd0a73e19be... mmc-utils: upgrade to latest revision
    applied 6ced13c3ba01... mpg123: upgrade 1.30.0 -> 1.30.1
    applied 88e8b4e641bf... pango: upgrade 1.50.7 -> 1.50.8
    applied 38e5774951d6... piglit: upgrade to latest revision
    applied 44e7cbcec9de... python3-dtschema: upgrade 2022.5 -> 2022.7
    applied c5f4574625ee... python3-hypothesis: upgrade 6.48.2 -> 6.50.1
    applied 4048b96306ed... python3-setuptools-rust: upgrade 1.3.0 -> 1.4.1
    applied 342e08990229... python3-setuptools-scm: upgrade 7.0.3 -> 7.0.5
    applied 045d05c5f734... python3-setuptools: upgrade 62.6.0 -> 63.2.0
    applied a0242659796f... python3-zipp: upgrade 3.8.0 -> 3.8.1
    applied ac35dec16576... sqlite3: upgrade 3.39.0 -> 3.39.1
    applied be85ae6f6c33... vala: upgrade 0.56.1 -> 0.56.2
    applied f6420c9aa6ac... wayland-protocols: upgrade 1.25 -> 1.26
    applied 5571169234ae... webkitgtk: upgrade 2.36.3 -> 2.36.4
    applied 6bafed6b3041... xwayland: upgrade 22.1.2 -> 22.1.3
    applied a0a75df2cb25... epiphany: upgrade 42.2 -> 42.3
    applied e0a76cfdd465... xf86-input-keyboard: remove the recipe
    applied 8a6f85709225... udev-extraconf:mount.sh: fix a umount issue
    applied a0e690138c6c... perf: fix reproduciblity in older releases of Linux
    applied e689476c4cae... glibc: make glibc-dev depend on kernel headers
    applied b890bca84d75... base/reproducible: Change Source Date Epoch generation methods
    applied 54ba1dbbe9a5... efivar: fix import functionality
    applied 10fc34c85e36... bind: Remove legacy python3 PACKAGECONFIG code
    applied 25248acfdf92... initscripts: run umountnfs as a KILL script
    applied 960ddcc609b3... vim: Upgrade 9.0.0021 -> 9.0.0063
    applied d69229e7247f... gcc-runtime: Use --with-target-subdir for baremetal targets
    applied 17e2eaed036e... package_manager/ipk: do not pipe stderr to stdout
    applied fa4b74a5a782... zstd: do verbose builds
    applied 454a0ea700b1... zlib: remove historical movement of libz.so to /lib
    applied e49831d1f8e4... oeqa/selftest: rename git.py to intercept.py
    applied c5bc2d2fe66f... systemd: Drop backported patch applied in 251.3
    applied 591f14c698f4... gcc-runtime: Use static dummy libstdc++
    applied a52a230540c8... libgcc: Fix standalone target builds with usrmerge distro feature
    applied 8b1fdf459355... linux-firwmare: restore WHENCE_CHKSUM variable
    applied 6428dcc6f6ae... python3-setuptools: move patch from 'files' to 'python3-setuptools'
    applied 2ace04c8f3ff... kernel.bbclass: pass LD also in savedefconfig
    applied e857abbfcba5... oeqa/gotoolchain: put writable files in the Go module cache
    applied a87284d4ab7f... oeqa/gotoolchain: set CGO_ENABLED=1
    applied 3ed71f4ff0c7... qemu: add io_uring PACKAGECONFIG
    applied 6749e2908204... strace: set COMPATIBLE_HOST for riscv32
    applied 5204de3f8df8... cargo-cross-canadian: Use SDK's flags during target linking
    applied d48c7e45494e... rust-common: Set llvm-target correctly for cross SDK targets
    applied 276c6ffe5f4d... rust-cross-canadian: Fix ordering of target json config generation
    applied 1900f5b6078c... rust-cross/rust-common: Merge arm target handling code to fix cross-canadian
    applied 97e267f6df60... rust-cross: Simplfy the rust_gen_target calls
    applied a02bb3b794fe... rust-common/rust-cross: Clean up target json generation code
    applied 1e04c8aafbe5... rust-target-config: Create new class to contain target json config generation
    applied e75e781a480d... rust-target-config: Allow the targets generated to be configurable
    applied 5bb7d810f039... native: Clear TUNE_FEATURES/ABIEXTENSION
    applied 1e3e20e92e3c... oeqa/sdk: Add basic rust cargo test
    applied 2e25ddcaeab8... populate_sdk: Add SDK toolchain language selection support
    applied c6d0348206b5... devtool: error out when workspace is using old override syntax
    applied 30ae37b756d2... rng-tools: Change systemd service name to work with sysvinit
    applied 76c40f6489bc... runqemu: Add missing space on default display option
    applied d902ba9e1561... default-distrovars: seccomp doesn't support microblaze
    applied 2b096a024f99... openssl: Move microblaze to linux-latomic config
    applied eb8a2753efff... elfutils: Microblaze does not support symvers
    applied 99779299f76f... systemd: Fix conflict between glibc mount.h and kernel mount.h
    applied 130e9b341db6... mesa: fix compile error when debug build enabled
    applied a115aa91aea9... populate_sdk_base: Fix mingw override name
    applied 9c45fd0b89db... archiver.bbclass: remove unsed do_deploy_archives[dirs]
    applied 29c52d7b268e... toolchain-scripts.bbclass: adjust toolchain_create_tree_env_script to better replicate (e)SDK
    applied 0f151cd090c7... meta-ide-support: adjust to provide (e)SDK experience directly in a yocto build
    applied 3afd79df9e93... oeqa/sdk: add a test class for running SDK tests directly in a Yocto build
    applied 638f988602a2... oeqa/sdk: allow epoxy/galculator tests to run in esdk and direct yocto builds
    applied 3c940fa09aa9... meson: provide relocation script and native/cross wrappers also for meson-native
    applied 9b3fcb0d9164... selftest/meta_ide: add a test for running SDK tests directly in a yocto build
    applied d08e47312741... poky.conf: remove EOL and Centos7 hosts
    applied e1a2b1d1b3c1... poky: Enable debug-kernel for SPDX license manifests
    applied 895779fd7e7c... bitbake: bb/utils: remove: check the path again the expand python glob
    applied ace415e6221c... bitbake: bb/utils: movefile: use the logger for printing
    applied 48a6d84de107... bitbake: runqueue: add cpu/io pressure regulation
    applied 403dfe91ea6d... create-spdx: Fix supplier field
    applied b9223d27bdeb... ltp: Add post release runtime fixes
    applied 2ef7affa31b4... oeqa/sdk/rust: Fix file deletion for multilib SDKs
    applied 195ea43f8f72... wic: add target tools to PATH when executing native commands
    applied c9db415375b4... wic/bootimg-efi: use cross objcopy when building unified kernel image
    applied af65f0cd842a... wic: depend on cross-binutils
    applied 848d57ebe523... cmake: remove CMAKE_ASM_FLAGS variable in toolchain file
    applied ad32aab27006... ltp: fix build with ld-is-gold in DISTRO_FEATURES
    applied e41d371dae7a... libarchive: Avoid mount.h conflict between kernel and glibc
    applied 06b27bb7981f... btrfs-tools: Use linux/mount.h instead of sys/mount.h
    applied 71d091359993... uboot-config.bbclass: Raise error for bad key
    applied eefe7a1cd1bf... scripts/oe-setup-builddir: make it known where configurations come from
    applied a7a8e995625c... gcc-sanitizers: Fix mount.h glibc 2.36 conflict
    applied 4fa546576507... hdparm: Fix build with glibc 2.36
    applied 8b82f25fe656... repo: upgrade 2.27 -> 2.28
    applied 44cc49c67984... vim: update from 9.0.0063 to 9.0.0115
    applied be0ca8e685cb... wic/bootimg-efi: Factor out some common bits
    applied e0825355ae00... wic/bootimg-efi: Add support for loading devicetree files
    applied 9f99474fa313... classes/sanity: Add comment about github & gitlab archives
    applied b8c5b2bfd530... devtool/upgrade: correctly clean up when recipe filename isn't yet known
    applied a782a46c3726... devtool/upgrade: catch bb.fetch2.decodeurl errors
    applied fda4c6bed149... lttng-modules: Fix build failure for kernel v5.15.58
    applied 096f688ec0d9... create-spdx: ignore packing control files from ipk and deb
    applied 6e756b150a24... pybootchartgui: render memory pressure as well
    applied ed8cb296471f... qemu: CVE-2022-35414 can perform an uninitialized read on the translate_fail path, leading to an io_readx or io_writex crash
    applied 44f92a3004b3... python3-attrs: upgrade 21.4.0 -> 22.1.0
    applied 81383b29d22d... python3-cython: upgrade 0.29.30 -> 0.29.32
    applied 55bd0b4313a0... python3-dbusmock: upgrade 0.28.1 -> 0.28.4
    applied 0d0f729edd37... python3-hatchling: upgrade 1.5.0 -> 1.6.0
    applied ed8d35d91169... python3-jsonschema: upgrade 4.7.2 -> 4.9.0
    applied ea1d4e87e02d... python3-scons: upgrade 4.3.0 -> 4.4.0
    applied c938393bf4f9... python3-setuptools: upgrade 63.2.0 -> 63.3.0
    applied 6c3a88e8dcf0... python3-pygobject: upgrade 3.42.1 -> 3.42.2
    applied 00a2a3040bd6... bitbake: bitbake-user-manual: npm fetcher: improve description of SRC_URI format
    applied fcb754793d0b... poky-floating-revisions.inc: remove xf86-input-keyboard entry
    applied 15c7fc317495... pybootchartgui: fix 2 SyntaxWarnings
    applied 7f4555e35f90... pybootchartgui: write the max values in the graph legend
    applied 5181c5acdcfd... python3-pip: upgrade 22.1.2 -> 22.2.1
    applied fc59c287247b... image_types_wic.bbclass: fix cross binutils dependency
meta-security 7ad5f6a9da -> 2a2d650ee0:
    applied f4a4c902ed2e... bubblewrap: Add recipe
    applied ac0a4ea0f84e... packagegroup-core-security.bb: add bubblewrap to pkg grp
    applied 71199365ff51... meta-security: Add recipe for libhoth
    applied 77910422fa5b... packagegroup-security-tpm: add libhoth to pkg grp
    applied affbb0d267d7... python3-privacyidea: update to 3.7.2
    applied 01d58e266d3f... suricata: update to 6.0.5
    applied 8cf673deaacc... chipsec: update to 1.8.7
    applied 2ca080928269... sssd: upgrade 2.7.1 -> 2.7.3
    applied 5a3002439639... fail2ban: add UPSTREAM_CHECK vars
    applied 770c7f3c05ad... ibmtpm2tss: fix SRC_URI
    applied edcb1537de5e... tpm2-tss-engine: add UPSTREAM_CHECK_URI
    applied 293d3ba9ade3... tpm2-tss: add UPSTREAM_CHECK_URI
    applied dc0d72e51adf... tpm2-tools: Add UPSTREAM_CHECK_URI
    applied c997039c17d0... tpm2-openssl: Add UPSTREAM_CHECK_URI
    applied 3584967332cc... tpm2-pkcs11: Add UPSTREAM_CHECK_URI
    applied 82379e07004c... tpm2-abrmd: add UPSTREAM_CHECK_URI
    applied c5c29696fe7e... tpm2-tcti-uefi: Add UPSTREAM_CHECK_URI
    applied 18a113ce8249... libtpm: upgrade 0.9.3 -> 0.9.5
    applied 0202c4ad1bc2... aide: add UPSTREAM_CHECK_URI
    applied 522c08e98d01... ecryptfs-utils: add UPSTREAM_CHECK_URI
    applied 3ccc0bf68a9e... krill: update to 0.9.6
    applied c48c6e588166... packagegroup-core-security: add krill to pkg grps
    applied d8d3824d2d92... packagegroup-core-security: add chipsec pkg to grp
    applied a3500e01e2d1... apparmor: update to 3.0.5
    applied 65d88fced24c... clamav: update to  0.104.4
    applied 55b5906ddd83... ibmtpm2tss: update version format
    applied 67c42369b33e... ibmswtpm2: fix UPSTREAM_CHECK
    applied e73c62adf731... ibmswtpm2: update to 1682
    applied 8a90b05e727f... swtpm: update to 0.7.3
    applied 4e0ba8453092... lkrg: update to 0.9.4
    applied 70859e8608b3... krill: only builds on x86/x86-64 and arm64
    applied 2a2d650ee03a... packagegroup-core-security: remove krill for some archs
meta-arm 80d60e7b1c -> 20a629180c:
    applied 20a629180ca3... runfvp: Stop the FVP when telnet shuts down cleanly
meta-openembedded 31c10bd3e6 -> 2eb39477a7:
    applied f5b2ec52f7ce... python3-redis: upgrade 4.3.3 -> 4.3.4
    applied c956b54ca04d... python3-cbor2: add missing build dependency
    applied a2cd474a5730... python3-simpleeval: remove 'build' build dependency
    applied ca039757994c... python3-pyrad: fix build system specification
    applied 388ba0d74d6e... python3-pytest-html: fix DEPENDS, don't depend on pip
    applied 29235912c650... python3-ansi2html: fix DEPENDS
    applied 8a96bf952783... python3-pytest-helpers-namespace: add missing build dependencies
    applied 847413d9cc14... python3-pyzmq: add missing build dependency
    applied 3752f4d63f58... python3-path: add missing build dependencies
    applied 1d726cf23865... python3-pytest-forked: loosen dependency checking
    applied 0f048c4c46fd... rsyslog: update 8.2202->8.2206
    applied 5dfcb2603dd8... freeradius: ignore patched CVEs
    applied 72a41f8e31ec... openflow: ignore unrelated CVEs
    applied 4d0789ec9fe1... python3-eth-hash: upgrade 0.3.3 -> 0.4.0
    applied de392652dc35... python3-ldap: upgrade 3.4.0 -> 3.4.2
    applied 823b699170da... python3-pillow: upgrade 9.1.1 -> 9.2.0
    applied dcbfed89d4fc... python3-socketio: upgrade 5.6.0 -> 5.7.0
    applied e560ab2ebd8b... python3-ujson: upgrade 5.3.0 -> 5.4.0
    applied 21fad1049eee... python3-web3: upgrade 5.29.2 -> 5.30.0
    applied aa691d59f4bd... python3-pylint: upgrade 2.14.3 -> 2.14.4
    applied 62fd84411765... python3-pyzmq: version bump 22.3.0 -> 23.2.0
    applied c7415233074c... poco: Link with libatomic on riscv32
    applied 19d05be57bda... python3-antlr4-runtime: Inherit setuptools3 instead of python_setuptools_build_meta
    applied 615624ab5769... catfish: Inherit setuptools3 instead of python_setuptools_build_meta
    applied cb3d45c4124d... python3-pycups: Inherit setuptools3 instead of python_setuptools_build_meta
    applied cb7d3afba838... python3-qface: Inherit setuptools3 instead of python_setuptools_build_meta
    applied 88541e824dd0... xscreensaver: Upgrade to 6.04
    applied 4012175df316... python3-aspectlib: updated the summary and added a description.
    applied ecbcc3bfc010... python3-jsonrpcclient: Added the jsonrpcclient Python package
    applied 1b3be50ad232... python3-oslash: added the oslash Python package
    applied 76c5388966b2... python3-jsonrpcserver: added the python3-oslash rdepends
    applied 261465eb6e2b... libplist: ignore patched CVEs
    applied efa12676dd06... meta-oe: ignore patched CVEs
    applied ed904e654184... mongodb: ignore unrelated CVEs
    applied 1642bfcb071a... php: ignore patched CVEs
    applied de4097f2304b... postgresql: ignore unrelated CVE
    applied 334a04aba883... poco: Link with libatomic on mips
    applied 63700a0c57c6... Revert "catfish: Inherit setuptools3 instead of python_setuptools_build_meta"
    applied 46a484bb459e... Revert "python3-pycups: Inherit setuptools3 instead of python_setuptools_build_meta"
    applied 0c2e41656735... Revert "python3-antlr4-runtime: Inherit setuptools3 instead of python_setuptools_build_meta"
    applied b175959e94e1... gegl: upgrade 0.4.36 -> 0.4.38
    applied 9e03cf40a6bd... libadwaita: upgrade 1.1.2 -> 1.1.3
    applied 83afd6a2f154... libgsf: upgrade 1.14.49 -> 1.14.50
    applied b88b492c21d3... nbdkit: upgrade 1.31.10 -> 1.31.12
    applied dfe92924ce09... irssi: upgrade 1.4.1 -> 1.4.2
    applied 6f342fe2415f... libp11: upgrade 0.4.11 -> 0.4.12
    applied 2b3bcd14c258... modemmanager: upgrade 1.18.8 -> 1.18.10
    applied 7568000c3162... pegtl: upgrade 3.2.6 -> 3.2.7
    applied feade3eb695c... PATCH] logcheck: upgrade 1.3.23 -> 1.3.24
    applied 8d7b56ff235e... php: upgrade 8.1.7 -> 8.1.8
    applied 6d05828e4a3a... ttf-fonts: fix URIs, upgrade 1.004 -> 2.004
    applied c77bc200813d... ndisc6: upgrade 1.0.5 -> 1.0.6
    applied c2fb0bd1ebe0... catfish: fix buildpaths issue
    applied ffdde0f2efa7... vboxguestdrivers: upgrade 6.1.34 -> 6.1.36
    applied 47f66939ff34... vboxguestdrivers: fix build failure on 32 bit architectures
    applied 0e46331835fc... libmtp: Upgrade to 1.1.20
    applied 0c4f3404ef36... libwebsockets: update to version 4.3.2
    applied e145b72b4248... python3-alembic: upgrade 1.8.0 -> 1.8.1
    applied aa95944c9d0e... python3-astroid: upgrade 2.11.6 -> 2.12.2
    applied a8485048aa91... python3-attr: upgrade 0.3.1 -> 0.3.2
    applied 291e82c9dc01... python3-blinker: upgrade 1.4 -> 1.5
    applied 56c37a7343cc... python3-cmd2: upgrade 2.4.1 -> 2.4.2
    applied 781c98091965... python3-ecdsa: upgrade 0.17.0 -> 0.18.0
    applied fc9c022a689d... python3-evdev: upgrade 1.5.0 -> 1.6.0
    applied 3bfd00e0fe2e... python3-fastjsonschema: upgrade 2.15.3 -> 2.16.1
    applied 4239137c6fde... python3-flask: upgrade 2.1.2 -> 2.1.3
    applied 6ea9cf247804... python3-googleapis-common-protos: upgrade 1.56.3 -> 1.56.4
    applied b91a71bfccf6... python3-iso3166: upgrade 2.0.2 -> 2.1.1
    applied c5d6b4569e69... python3-kiwisolver: upgrade 1.4.3 -> 1.4.4
    applied 016947fbbd8a... python3-lru-dict: upgrade 1.1.7 -> 1.1.8
    applied 99b8eb24d9bc... python3-portalocker: upgrade 2.4.0 -> 2.5.1
    applied a5edc0ed8553... python3-pyfanotify: upgrade 0.1.3 -> 0.2.0
    applied 82211eb6233b... python3-pylint: upgrade 2.14.4 -> 2.14.5
    applied 0b9e743adec5... python3-pytest-metadata: upgrade 2.0.1 -> 2.0.2
    applied 68a9fc5f75a7... python3-regex: upgrade 2022.6.2 -> 2022.7.9
    applied e4e0eacc8be2... python3-socketio: upgrade 5.7.0 -> 5.7.1
    applied 03c4831f445a... python3-stevedore: upgrade 3.5.0 -> 4.0.0
    applied f5645ac7212b... python-ptyprocess: fixed test_pass_fds
    applied b7e69905fbc8... python3-pyzmq: added ptest
    applied 702f26e2471d... python3-pyzmq: fixed oelint-adv warnings
    applied fbb406a1fc57... bigbuckbunny-1080p: update SRC_URI
    applied fb6af0ef0bee... README: Remove maintainer info for tvgamblin
    applied f22ecd862880... tracker: upgrade 3.3.1 -> 3.3.2
    applied c2cb0abc11ab... zenity: upgrade 3.42.1 -> 3.43.0
    applied e174de32efea... nbdkit: upgrade 1.31.12 -> 1.31.14
    applied 52be803ba5f6... stunnel: upgrade 5.64 -> 5.65
    applied 3b40c93f4471... unbound: upgrade 1.16.0 -> 1.16.1
    applied 1b43fcf335f2... wolfssl: upgrade 5.3.0 -> 5.4.0
    applied 75209f0de186... atkmm-2.36: upgrade 2.36.1 -> 2.36.2
    applied 82c6f50e0d1d... nanopb: upgrade 0.4.5 -> 0.4.6.4
    applied b85feca2818c... redis-plus-plus: upgrade 1.3.3 -> 1.3.5
    applied a487ec936266... redis: upgrade 7.0.2 -> 7.0.4
    applied d2a602787650... ser2net: upgrade 4.3.6 -> 4.3.7
    applied 5719b75341a4... unattended-upgrades: upgrade 2.6 -> 2.9.1
    applied 41d34e2a7936... valijson: upgrade 0.6 -> 0.7
    applied 6ba48fb9cc88... Add runtime dependencies for python3-supervisor
    applied 447de4d47ba2... Fix tigervnc crash due to missing xkbcomp rdepends
    applied 1d75a01bb5bc... Add python3-pycares 4.2.1
    applied 283204e24c82... Add python3-aiodns 3.0.0
    applied 86b58eb81986... googlebenchmark: upgrade 1.6.1 -> 1.7.0
    applied f563466af7a7... s-nail: fix buildpaths issue
    applied dfae13fc4097... python3-absl: upgrade 1.1.0 -> 1.2.0
    applied b56a22ea3cbf... python3-bitarray: upgrade 2.5.1 -> 2.6.0
    applied d67b1bcb5432... python3-eth-hash: upgrade 0.4.0 -> 0.5.0
    applied be6677870ddc... python3-google-api-python-client: upgrade 2.51.0 -> 2.54.0
    applied 05b34a3d3be7... python3-google-auth: upgrade 2.9.0 -> 2.9.1
    applied 2fdfd97ed731... python3-graphviz: upgrade 0.20 -> 0.20.1
    applied f85965f02719... python3-imageio: upgrade 2.19.3 -> 2.19.5
    applied b83cc192bee2... python3-lz4: upgrade 4.0.1 -> 4.0.2
    applied 7360d05b861b... python3-mypy: upgrade 0.961 -> 0.971
    applied b351031e39cf... python3-protobuf: upgrade 4.21.2 -> 4.21.3
    applied 2ffdc8e998c2... python3-pystemd: Upgrade 0.8.0 -> 0.10.0
    applied 2774a0b9b061... python3-elementpath: upgrade 2.5.3 -> 3.0.1
    applied b8a2f6744c82... python3-pymongo: upgrade 4.1.1 -> 4.2.0
    applied 989dd39d3924... python3-pyscaffold: upgrade 4.2.3 -> 4.3
    applied 49ef6e58e8f7... python3-regex: upgrade 2022.7.9 -> 2022.7.24
    applied 5cc6d9375eca... python3-rsa: upgrade 4.8 -> 4.9
    applied 8f3b3bd43c56... python3-sh: upgrade 1.14.2 -> 1.14.3
    applied e3aa95b9a2a0... python3-werkzeug: upgrade 2.1.2 -> 2.2.0
    applied 2eb39477a784... python3-xmlschema: upgrade 1.11.3 -> 2.0.1

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
