### PR TITLE
subtree update: 6cd13dad0e -> 2fc60b2a3c

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 20a629180ca3a15ea8687b3bdaf8c7cda8b42bbb
+last_revision = 53870ee43e5732d6d48f12ea120d25043a70b877
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 2eb39477a784673baefa59640909b827ebb689b2
+last_revision = e4f8e83541229888e63113debb21c3fde3a0e7d8
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,11 +20,11 @@ last_revision = b6a1645a97d2de7f08f7d37c7a8f2991ab45032d
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 2a2d650ee03af904d35c06134731b96b0feb2b60
+last_revision = 571af37e9c93fc4030794494f1d128a4457afe13
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = fc59c287247b5b4d2c0266d72a2b2830dc6e1ef8
+last_revision = 081a3655fbb10b83793f102b975e153e75240682
 


### PR DESCRIPTION
meta-openembedded 2eb39477a7 -> e4f8e83541:
    applied 7ca63e5454bd... polkit: Add --shell /bin/nologin to polkitd user
    applied 271282b1a557... polkit: update patches for musl compilation
    applied a52e78d44107... mariadb: Inherit pkgconfig
    applied d55a063a0a31... mariadb: Add packageconfig for lz4 and enable it
    applied 5f97fef85951... sshpass: add recipe
    applied f1247115d164... python3-dominate: upgrade 2.6.0 -> 2.7.0
    applied 9894b44b3bc7... python3-flask-login: upgrade 0.6.1 -> 0.6.2
    applied 8cadb9ece9b2... python3-google-api-python-client: upgrade 2.54.0 -> 2.55.0
    applied 5331bab6d371... python3-haversine: upgrade 2.5.1 -> 2.6.0
    applied 23fd82ca29d2... python3-imageio: upgrade 2.19.5 -> 2.21.0
    applied 9abda48aa1fb... python: add Pydantic data validation package
    applied ca5f1dde5416... ibus: Swith to use main branch instead of master
    applied 1bf83255aee9... net-snmp: set ac_cv_path_PSPROG
    applied 9444f67b261f... ntpsec: Add UPSTREAM_CHECK_URI
    applied 59eff6269c4f... postgresql: Fix the buildpaths issue
    applied f550d1fe6a14... gedit: upgrade 42.1 -> 42.2
    applied 5e7d573bcda5... libwacom: upgrade 2.3.0 -> 2.4.0
    applied ea95e48d685d... htpdate: upgrade 1.3.4 -> 1.3.5
    applied 2736076d7bde... nbdkit: upgrade 1.31.14 -> 1.31.15
    applied 8a50039955ae... pure-ftpd: upgrade 1.0.50 -> 1.0.51
    applied 1a71d99fef7e... pcsc-lite: upgrade 1.9.0 -> 1.9.8
    applied 0f7c6c2901fb... ccid: upgrade 1.4.33 -> 1.5.0
    applied d6a30ef441ad... avro-c: upgrade 1.11.0 -> 1.11.1
    applied 5e3bd1a83e3b... debootstrap: upgrade 1.0.126 -> 1.0.127
    applied 7dae7bfe1853... freerdp: upgrade 2.7.0 -> 2.8.0
    applied eb7b368ffce0... icewm: upgrade 2.9.7 -> 2.9.8
    applied 11d5fe77c874... libmxml: upgrade 3.3 -> 3.3.1
    applied 21233e7ac9da... poco: upgrade 1.12.0 -> 1.12.1
    applied d09755e8e3f0... fluentbit Upgrade to 1.3.5 -> 1.9.6
    applied 0d73ddc99832... libass: update to v1.16.0
    applied 769a67086be2... xfontsel: upgrade 1.0.6 -> 1.1.0
    applied 09700552e2d6... xmessage: upgrade 1.0.5 -> 1.0.6
    applied ca0c0abe863c... xrefresh: upgrade 1.0.6 -> 1.0.7
    applied 85b7ff3a38a7... zabbix: upgrade 6.0.5 -> 6.2.1
    applied 8ad020938f86... python3-jsonrpcserver: add patch to use importlib.resources instead of pkg_resources
    applied 28a3b1eba5b8... imagemagick: add PACKAGECONFIG for C++ bindings
    applied 3100d58b571e... python3-matplotlib: don't use PYTHON_PN
    applied db74afe6f412... python3-matplotlib: add packaging to RDEPENDS
    applied 9026f792e434... python3-matplotlib: bump to 3.5.2
    applied 1c91de67b498... freeradius: Fix buildpaths issue
    applied 5abd81567d5e... openipmi: Fix buildpaths issue
    applied 42f8c22fcfde... strongswan: upgrade 5.9.6 -> 5.9.7
    applied 565e31cb05df... Add python-requests-unixsocket recipe
    applied 4f2025e8d2f1... apache2: Fix the buildpaths issue
    applied 8b76b6c8e3ff... frr: fix buildpaths issue
    applied 7c440945326d... networkmanager: fix iptables and nft paths
    applied ba38106eb4be... spdlog: update to v1.10.0
    applied 8f222c9f3754... xrdp: upgrade 0.9.18 -> 0.9.19
    applied a7346d2bb1a6... yasm: fix buildpaths warning
    applied 0c4041b16639... python3-protobuf: upgrade 4.21.3 -> 4.21.4
    applied b69fdf498163... python3-pycodestyle: upgrade 2.8.0 -> 2.9.0
    applied f6eb522f0ca9... python3-pyflakes: upgrade 2.4.0 -> 2.5.0
    applied 278f2ab98034... python3-pythonping: upgrade 1.1.1 -> 1.1.2
    applied 9eb2918f2b9c... python3-regex: upgrade 2022.7.24 -> 2022.7.25
    applied d432004d2c57... python3-werkzeug: upgrade 2.2.0 -> 2.2.1
    applied 349f0be07381... vboxguestdrivers: fix build against 5.19 kernel / libc-headers
    applied e7f3b224d958... kronosnet: Upgrade to 1.24
    applied 32b42cd3e52b... ostree: Upgrade to 2022.5 release
    applied f7ae5c6dca35... sdbus-c++-libsystemd: Fix build with glibc 2.36
    applied 8d7a59a813eb... xfstests: Upgrade to v2022.07.10
    applied 0b031b570411... autofs: Fix build with glibc 2.36
    applied 5a93ce005d6f... dnf-plugin-tui: Fix somw issue in postinstall process.
    applied abe35f5953af... xrdp: Fix buildpaths warning.
    applied e3dac1a87f4e... waylandpp: add recipe
    applied 9ef040501ec5... zfs: update to v2.1.5
    applied ee3c680c3002... audit: Upgrade to 3.0.8 and fix build with linux 5.17+
    applied d799db35da88... lapack: add packageconfig for lapacke
    applied 2918a07a049a... pcp: Add to USERADD_PACKAGES instead of override
    applied a8e33c970159... mozjs: Use RUST_HOST_SYS and RUST_TARGET_SYS
    applied 73b09ba5cbaa... libftdi: update to 1.5
    applied 0f8dced8c7b7... fluentbit: Fix build with clang
    applied ad978133a1a1... audit: Fix build with musl
    applied bc2b1482a0a7... fluentbit: Fix build with musl
    applied 8204ee52dea7... klibc: Upgrade to 2.0.10
    applied 5cefe61d1816... nspr: fix buildpaths issue
    applied 78fe37bb9c14... lmdb: Don't inherit base
    applied 284f38a12b3c... gnome-keyring,cunit,xfce4-panel: Do not inherit remove-libtool class here
    applied bf4a826c7de5... net-snmp: upgrade 5.9.1 -> 5.9.3
    applied 62fd541101c1... libgpiod: Detect ptest using PTEST_ENABLED
    applied 68d5d03be43f... ostree: Cleanup PACKAGECONFIGs
    applied 67b3fc7ad000... libsdl2-ttf: upgrade 2.0.18 -> 2.20.0
    applied 02fc7f371d95... mpd: Update to 0.23.8
    applied 3d3d7b1d6b81... openipmi: Enable largefile cflags
    applied 015fcc405399... liblockfile: fix buildpaths issue
    applied 4785cc2cd3bc... fuse3: support ptest
    applied b3c5234ccaf0... python3-nocasedict: Upgrade 1.0.3 -> 1.0.4
    applied 868ad28aad06... python3-frozenlist: Upgrade 1.3.0 -> 1.3.1
    applied 5efa61083ad3... python3-networkx: Upgrade 2.8.4 -> 2.8.5
    applied 42a1c085e692... python3-pyhamcrest: Upgrade 2.0.3 -> 2.0.4
    applied 6538118f602e... proftpd: Always enable largefile support
    applied 4114fdc78be7... netperf: Always enable largefile support
    applied a203981a2ac4... openipmi: Always enable largefile support
    applied 38ce750aac40... unbound: Always enable largefile support
    applied bc47b413ab79... sysbench: Always enable largefile support
    applied 6f1f432af3a4... libmtp: Always enable largefile support
    applied d2e903b5d60c... vboxguestdrivers: make kernel shared directory dependency explicit
    applied fb331cb62eaf... image_types_sparse: Pad source image to block size
    applied 9862a017fa7f... image_types_sparse: Generate "don't care" chunks
    applied 09dd36bedf02... toybox: Fix build with glibc 2.36+
    applied c1d5aa461099... xfstests: Upgrade to 2022.07.31 release
    applied fdad7782b926... libmpd: Fix function returns and casts
    applied 15a1c43d245a... redis: fix do_patch fuzz warning
    applied 988566884df1... cifs-utils: upgrade 6.15 -> 7.0
    applied c0a353d11d17... geocode-glib: upgrade 3.26.3 -> 3.26.4
    applied 757dedbc811b... gjs: upgrade 1.72.1 -> 1.72.2
    applied 6d8fbbfc2f20... htpdate: upgrade 1.3.5 -> 1.3.6
    applied e29afd0c0c0c... icewm: upgrade 2.9.8 -> 2.9.9
    applied a9d623b5ef3a... ipc-run: upgrade 20200505.0 -> 20220807.0
    applied 4fa7d9ee9ad5... iwd: upgrade 1.28 -> 1.29
    applied 1180d651a7ac... ldns: upgrade 1.8.1 -> 1.8.2
    applied 23324f0304c5... libadwaita: upgrade 1.1.3 -> 1.1.4
    applied 670258af17b7... libencode-perl: upgrade 3.18 -> 3.19
    applied 6ae8e84b2e58... libmime-charset-perl: upgrade 1.012.2 -> 1.013.1
    applied 120321604e88... libtest-warn-perl: upgrade 0.36 -> 0.37
    applied 68df7a17496e... nano: upgrade 6.3 -> 6.4
    applied e99695e7718d... nbdkit: upgrade 1.31.15 -> 1.32.1
    applied 0b751c8dc5b7... netdata: upgrade 1.35.1 -> 1.36.0
    applied 6a94da5d1746... fio: upgrade 3.30 -> 3.31
    applied ca831e8d5b3d... nlohmann-json: upgrade 3.10.5 -> 3.11.2
    applied 2664fb5ec37b... poco: upgrade 1.12.1 -> 1.12.2
    applied c484ec130065... postgresql: upgrade 14.4 -> 14.5
    applied a2ce32d26a45... poppler: upgrade 22.07.0 -> 22.08.0
    applied dd302242f64c... smarty: upgrade 4.1.1 -> 4.2.0
    applied b4a28c8c8436... tracker: upgrade 3.3.2 -> 3.3.3
    applied 0a58426ed073... uftp: upgrade 5.0 -> 5.0.1
    applied aa4f7c4c3e80... xdg-user-dirs: upgrade 0.17 -> 0.18
    applied db50023da410... python3-aiohue: Upgrade 4.4.2 -> 4.5.0
    applied 05382d0d7671... python3-google-auth: upgrade 2.9.1 -> 2.10.0
    applied a78559860e01... python3-humanize: upgrade 4.2.3 -> 4.3.0
    applied af07c6f02f2d... python3-hexbytes: upgrade 0.2.2 -> 0.2.3
    applied b79c07b3302a... python3-imageio: upgrade 2.21.0 -> 2.21.1
    applied 9dab2b4c6656... python3-nocaselist: upgrade 1.0.5 -> 1.0.6
    applied 1fa173ed52ad... python3-protobuf: upgrade 4.21.4 -> 4.21.5
    applied 8c9052d7b0f7... python3-pycares: upgrade 4.2.1 -> 4.2.2
    applied 0268062ac909... python3-pycodestyle: upgrade 2.9.0 -> 2.9.1
    applied 5a9e14e2beae... python3-pyzmq: upgrade 23.2.0 -> 23.2.1
    applied 6ff1c0494658... python3-setuptools-declarative-requirements: upgrade 1.2.0 -> 1.3.0
    applied 3e6b512ed0aa... python3-sqlalchemy: upgrade 1.4.39 -> 1.4.40
    applied cc74cd4d568f... python3-werkzeug: upgrade 2.2.1 -> 2.2.2
    applied 689460263957... python3-xmlschema: upgrade 2.0.1 -> 2.0.2
    applied 7581cea9763e... python3-yappi: upgrade 1.3.5 -> 1.3.6
    applied 08dbfb24acce... python3-autobahn: upgrade 22.6.1 -> 22.7.1
    applied 91b23fe29a6e... python3-engineio: upgrade 4.3.3 -> 4.3.4
    applied 41339e1425e4... python3-flask: upgrade 2.1.3 -> 2.2.2
    applied e7ac3e713ae2... python3-gcovr: upgrade 5.1 -> 5.2
    applied 2fb322886439... python3-google-api-python-client: upgrade 2.55.0 -> 2.56.0
    applied 902a6876f24d... python3-asttokens: upgrade 2.0.5 -> 2.0.7
    applied c755fd315da0... python3-zeroconf: upgrade 0.38.7 -> 0.39.0
    applied ada413e13df7... libipc-signal-perl: Fix LICENSE string
    applied 5ad68a63b81c... libdigest-hmac-perl: Fix LICENSE string
    applied fa9f52c6b5d8... libio-socket-ssl-perl: Fix LICENSE string
    applied b4fffac1e1e4... libdigest-sha1-perl: Fix LICENSE string
    applied 75eb15e16c81... libmime-types-perl: Fix LICENSE string
    applied b2162c2c469c... libauthen-sasl-perl: Fix LICENSE string
    applied 3e32cad36830... libnet-ldap-perl: Fix LICENSE string
    applied 2000da265c3d... libxml-libxml-perl: Fix LICENSE string
    applied 5551711ba5a7... libnet-telnet-perl: Fix LICENSE string
    applied 5c10c3fd4575... libproc-waitstat-perl: Fix LICENSE string
    applied 164b3090b685... python3-pyperf: Upgrade 2.3.0 -> 2.4.1
    applied 7e6998f43dfe... python3-eth-abi: Upgrade 3.0.0 -> 3.0.1
    applied f74aa93fbe83... python3-cytoolz: Upgrade 0.11.2 -> 0.12.0
    applied 330b46745ccf... python3-yarl: Upgrade 1.7.2 -> 1.8.1
    applied 260577074523... python3-term: Upgrade 2.3 -> 2.4
    applied 4ff83dfb5a9f... audit: Revert the tweak done in configure step in do_install
    applied 9ed1e62bbb17... mpd: Upgrade to 0.23.9
    applied 6c998191cd10... fluentbit: Use CMAKE_C_STANDARD_LIBRARIES cmake var to pass libatomic
    applied d1fb6cd8a55a... fluentbit: Upgrade to 1.9.7 and fix build on x86
    applied febd004e6b63... klibc: Fix build with kernel 5.19 headers
    applied b20af98b5ad2... spdlog: Fix CMake flag
    applied e4f8e8354122... dlt-daemon: fix dlt-system.service failed since buffer overflow
poky fc59c28724 -> 081a3655fb:
    applied 2ead8dc18bb6... oeqa/selftest/sstate: Ensure tests are deterministic
    applied 7f902fb29f33... nativesdk: Clear TUNE_FEATURES
    applied f2bd326370e3... populate_sdk_base: Disable rust SDK for MIPS n32
    applied 0246dd5f5024... selftest/reproducible: Exclude rust/rust-dbg for now until we can fix
    applied cf1092012a7d... conf/distro/no-static-libs: Allow static musl for rust
    applied 52ef977c958d... rust-target-config: Add mips n32 target information
    applied d183c36c81e8... rust-common: Add CXXFLAGS
    applied ae3950ec5a42... rust-common: Drop export directive from wrappers
    applied b2ffb96705e9... rust-common: Rework wrappers to handle musl
    applied 411304c3e99f... rust: Work around reproducibility issues
    applied 5c45b73c8fa4... rust: Switch to use RUST_XXX_SYS consistently
    applied 3350658cb24c... rust.inc: Rename variables to make code clearer
    applied c2f5b71c9beb... rust.inc: Fix cross build llvm-config handling
    applied 9e5cbb80f0eb... rust/mesa: Drop obsolete YOCTO_ALTERNATE_MULTILIB_NAME
    applied 9a093d034889... rust-target-config: Show clear error when target isn't defined
    applied b1d8d2a3bfe4... rust: Generate per recipe target configuration files
    applied 1c8444bd380d... rust-common/rust: Improve bootstrap BUILD_SYS handling
    applied 1ab2fd2d036e... cargo_common: Handle build SYS as well as HOST/TARGET
    applied 749c85917f38... rust-llvm: Enable nativesdk variant
    applied 82dc055d96f2... rust.inc: Fix for cross compilation configuration
    applied d172b76c264f... rust-common: Update to match cross targets
    applied 0b374dc724ca... rust-target-config: Make target workaround generic
    applied cdd65a42a8b7... rust-common: Simplify libc handling
    applied 251f55374d26... cargo: Drop cross-canadian variant and fix/use nativesdk
    applied 1b7b5c37598b... rust-common: Set rustlibdir to match target expectation
    applied 0a01b5ab973e... rust-cross-canadian: Simplify and fix
    applied 38934deeea87... rust: Drop cross/crosssdk
    applied 16b4ac3f558f... rust: Enable nativesdk and target builds + replace rust-tools-cross-canadian
    applied e1dcfcdbfa65... rust: Fix musl builds
    applied 1e8f4ee56ad1... rust: Ensure buildpaths are handled in debug symbols correctly
    applied a514d1cb530f... rust: Update README
    applied 865658a6fefd... linux-yocto/5.15: update to v5.15.58
    applied 8c4b7427ed26... linux-yocto/5.10: update to v5.10.134
    applied f2db034384f1... linux-yocto-rt/5.15: update to -rt48 (and fix -stable merge)
    applied 42f333f6e297... linux-libc-headers: update to v5.19
    applied 83ac47441407... kernel-devsrc: support arm v5.19+ on target build
    applied 5eb28fc7a123... kernel-devsrc: support powerpc on v5.19+
    applied b7eec1ffa14d... lttng-modules: fix build against mips and v5.19 kernel
    applied 1f28ef830029... qemu: Fix build with glibc 2.36
    applied ce119b061747... mtd-utils: Fix build with glibc 2.36
    applied fd3c99be517a... stress-ng: Upgrade to 0.14.03
    applied ec9ec0b349ec... bootchart2: Fix build with glibc 2.36+
    applied add915e205b5... ltp: Fix sys/mount.h conflicts needed for glibc 2.36+ compile
    applied 4e95bdc09bce... efivar: Fix build with glibc 2.36
    applied ce18cc1d7237... relocate_sdk.py: ensure interpreter size error causes relocation to fail
    applied c8e4c239f2e4... oeqa devtool: Add tests to cover devtool handling of various git URL styles
    applied aa83bdc43945... glibc : stable 2.35 branch updates
    applied 5f1bb85cfa32... glibc: revert one upstream change to work around broken DEBUG_BUILD build
    applied 35183c1b3325... selftest/wic: Tweak test case to not depend on kernel size
    applied 377a671e07ff... bitbake: runqueue: Ensure deferred tasks are sorted by multiconfig
    applied 645aa3951249... bitbake: runqueue: Improve deadlock warning messages
    applied c58fca98e495... bitbake: runqueue: Drop deadlock breaking force fail
    applied fdc9d9e4fc38... bitbake: siggen: Fix insufficent entropy in sigtask file names
    applied 3c1ed4a7dade... rust-common: Remove conflict with utils create_wrapper
    applied 39d44df6029b... linux-yocto: introduce v5.19 reference kernel recipes
    applied 5ba3b8619de8... meta/conf: update preferred linux-yocto version to v5.19
    applied 4ba4fe9117c3... linux-yocto: drop v5.10 reference kernel recipes
    applied ab5f684a9c48... linux-yocto/5.15: update to v5.15.59
    applied d5dc5907721e... linux-yocto/5.15: fix reproducibility issues
    applied dcbdc09a08d1... linux-yocto/5.19: cfg: update x32 configuration fragment
    applied da0861915c2c... linux-yocto/5.19: fix reproducibility issues
    applied 8bc77f0dc6a8... kern-devsrc: Drop auto.conf creation
    applied 8b99059878e9... kmscube: address linux 5.19 fails
    applied 2ab59bd0323f... poky: update preferred version to v5.19
    applied db242b92f76f... poky: change preferred kernel version to 5.15 in poky-alt
    applied e53b3008b30f... yocto-bsp: drop v5.10 bbappend and create 5.19 placeholder
    applied 7275846f45db... cargo: Work around host system library conflicts
    applied 0650f9c770cf... rust-cross-canadian: Use shell from SDK, not the host
    applied 0bb5f1f99da2... cracklib: Drop using register keyword
    applied 6ff9060c7f11... util-linux: Define pidfd_* function signatures
    applied 56343f4a11f0... util-linux: Upgrade to 2.38.1
    applied fdcb16c6b731... tcp-wrappers: Fix implicit-function-declaration warnings
    applied b9a57cad4db4... gdbserver : add selftest
    applied 078da710ab97... libmnl: remove unneeded SRC_URI 'name' option
    applied 600a05afaeaa... rpm: update 4.17.0 -> 4.17.1
    applied 7d219c244079... go: update 1.18.4 -> 1.19
    applied 936f15bc72b2... bluez5: update 5.64 -> 5.65
    applied c0e4f1de9098... python3-pip: update 22.2.1 -> 22.2.2
    applied 461f6575fa8e... ffmpeg: update 5.0.1 -> 5.1
    applied 4feac920c221... iproute2: upgrade 5.18.0 -> 5.19.0
    applied 1910a7055e93... harfbuzz: upgrade 4.4.1 -> 5.1.0
    applied f862d6873a66... libwpe: upgrade 1.12.0 -> 1.12.2
    applied 7e8177dfa173... bind: upgrade 9.18.4 -> 9.18.5
    applied f335acfc8120... diffoscope: upgrade 218 -> 220
    applied 0e29a5003b03... ell: upgrade 0.51 -> 0.52
    applied 67af9fa94044... gnutls: upgrade 3.7.6 -> 3.7.7
    applied 2b3e47e8cba8... iso-codes: upgrade 4.10.0 -> 4.11.0
    applied 5c29110f0c8e... kea: upgrade 2.0.2 -> 2.2.0
    applied 79363fc21548... kexec-tools: upgrade 2.0.24 -> 2.0.25
    applied 386c3768de59... libcap: upgrade 2.64 -> 2.65
    applied f60880d8335b... libevdev: upgrade 1.12.1 -> 1.13.0
    applied 2b06c085a1c2... libnotify: upgrade 0.8.0 -> 0.8.1
    applied aa4f5a2791e3... libwebp: upgrade 1.2.2 -> 1.2.3
    applied 3f04c31f61d2... libxcvt: upgrade 0.1.1 -> 0.1.2
    applied 16ff8b482288... mesa: upgrade 22.1.3 -> 22.1.5
    applied 2deabf0e4f03... mobile-broadband-provider-info: upgrade 20220511 -> 20220725
    applied 245e9fe4df4f... nettle: upgrade 3.8 -> 3.8.1
    applied e63f240bbec4... piglit: upgrade to latest revision
    applied 9f73d180c978... puzzles: upgrade to latest revision
    applied 8a6ba1ed40fa... python3: upgrade 3.10.5 -> 3.10.6
    applied d079caccb374... python3-dtschema: upgrade 2022.7 -> 2022.8
    applied 33b039928cac... python3-hypothesis: upgrade 6.50.1 -> 6.54.1
    applied 62cf15ec0b2c... python3-jsonschema: upgrade 4.9.0 -> 4.9.1
    applied 49e6f634fd2f... python3-markdown: upgrade 3.3.7 -> 3.4.1
    applied c610953499d1... python3-setuptools: upgrade 63.3.0 -> 63.4.1
    applied 2f04fe29788e... python3-sphinx: upgrade 5.0.2 -> 5.1.1
    applied de5e91a62ff5... python3-urllib3: upgrade 1.26.10 -> 1.26.11
    applied 335d6d3be08f... sqlite3: upgrade 3.39.1 -> 3.39.2
    applied 2358923e6269... sysklogd: upgrade 2.4.0 -> 2.4.2
    applied 2dbb1706aa77... webkitgtk: upgrade 2.36.4 -> 2.36.5
    applied 7fea5b909e74... syslinux: Fix build with glibc-2.36
    applied b1c27d69f67b... syslinux: refresh patches with devtool
    applied d16bdcd4783f... libpam: use /run instead of /var/run in systemd tmpfiles
    applied 24c198e58ea4... rng-tools: Replace obsolete "wants systemd-udev-settle"
    applied 883aea9b6e02... buildhistory: Only use image-artifact-names as an image class
    applied 83e7f668ae6b... rust: Remove unneeded RUST_TARGETGENS settings
    applied b5200793c266... meta-skeleton/hello-mod: Switch to SPDX-License-Identifier
    applied 0b7567d577fd... perf: Fix reproducibility issues with 5.19 onwards
    applied a74792b15dd6... selftest/runtime_test/incompatible_lic: Use IMAGE_CLASSES for testimage
    applied e8de01e7989a... testexport: Fix to work as an image class
    applied f14e3f3a31ac... testexport: Use IMAGE_CLASSES for testimage
    applied 0f6817f2a455... selftest/runtime_test: Use testexport in IMAGE_CLASSES, not globally
    applied f5c616d5aff3... bitbake: runqueue: add memory pressure regulation
    applied 8a1afec0d592... bitbake: build: prefix the tasks with a timestamp in the log task_order
    applied be8ddaed17dd... bitbake: BBHandler: Allow earlier exit for classes not found
    applied 12d7157a4145... bitbake: BBHandler: Make inherit calls more directly
    applied e19ce4191d94... bitbake: bitbake: Add copyright headers where missing
    applied 7bd328f9d24b... bitbake: BBHandler/cooker: Implement recipe and global classes
    applied 971d5f7b81d5... classes: Add copyright statements to files without one
    applied 7350e82ce128... scripts: Add copyright statements to files without one
    applied ff525695f27c... classes: Add SPDX license identifiers
    applied ce08cf4825f0... lib: Add copyright statements to files without one
    applied 10317912ee31... insane: Update to allow for class layout changes
    applied fd1517e2b51a... classes: Update classes to match new bitbake class scope functionality
    applied dc850a1066e7... recipetool: Update for class changes
    applied 39197039e903... archiver.bbclass: some recipes that uses the kernelsrc bbclass uses the shared source
    applied 54dd5c56fc76... classes: rootfs-postcommands: autologin root on serial-getty
    applied 0f974fd6a5ef... perl-cross: Correct function signatures in configure_func.sh
    applied 483f285c4de1... perl: Pass additional flags to enable lfs and gnu source
    applied a0402e782222... sysvinit: Fix mount.h conflicts seen with glibc 2.36+
    applied e08a78c45345... glibc: Bump to 2.36
    applied f24bfd4a3e86... glibc: fix new upstream build issue with DEBUG_BUILD build
    applied 4ed54513b93c... glibc: Update patch status
    applied dcb596d8d6a3... uboot-config.bbclass: Don't bail out early in multi configs
    applied e5bd1a6b14d8... apt: fix nativesdk-apt build failure during the second time build
    applied 0b85162b9c22... wic: add 'none' fstype for custom image
    applied 16b42a139ccd... lttng-modules: replace mips compaction fix with upstream change
    applied e2bc5106234e... zip: Enable largefile support based on distro feature
    applied 537c61b2cabc... zip: Make configure checks to be more robust
    applied f40f214e7182... unzip: Fix configure tests to use modern C
    applied 8cfe74e01adf... unzip: Enable largefile support when enabled in distro
    applied e4f3c93c33b3... iproute2: Fix netns check during configure
    applied 8bb753d5856a... dev-manual: use proper note directive
    applied d400578e1457... docs: conf.py: update yocto_git base URL
    applied 2d40a436c7e6... docs: README: add TeX font package required for building PDF
    applied 3eb3888ef004... docs: ref-manual: system-requirements: add missing packages
    applied f7763317f8f9... system-requirements.rst: remove EOL and Centos7 hosts
    applied ea613c8f70d5... kernel-dev: working with kernel using devtool does not require building and installing eSDK
    applied 2ee595026628... sdk-manual: describe how to use extensible SDK functionality directly in a Yocto build
    applied 206656437d1d... uninative: Upgrade to 3.7 to work with glibc 2.36
    applied 6f892f5384ff... linux-yocto: prepend the the value with a space when append to KERNEL_EXTRA_ARGS
    applied 85437a157e80... dropbear: merge .inc into .bb
    applied 95832841bf1d... rust: update 1.62.0 -> 1.62.1
    applied 3dff0917e763... cmake: update 3.23.2 -> 3.24.0
    applied 4675bd334958... weston: upgrade 10.0.1 -> 10.0.2
    applied 51aa1c66dded... patchelf: update 0.14.5 -> 0.15.0
    applied fd65379613ad... patchelf: replace a rejected patch with an equivalent uninative.bbclass tweak
    applied bd0beddcb1f1... weston: exclude pre-releases from version check
    applied a9e80e935c47... create-spdx: handle links to inaccessible locations
    applied 9175df4ee714... qemux86-64: Allow higher tunes
    applied c80405aa9d32... cve-check: Don't use f-strings
    applied 271bbd9cc3d4... json-c: Add ptest for json-c
    applied 21cfb871f7da... glibc: Bump to latest 2.36 branch
    applied 7786b09212d6... poky.conf: add ubuntu-22.04 to tested distros
    applied 66af02e576dd... gstreamer1.0-plugins-base: Include required system headers for isspace() and sscanf()
    applied 595d98accc9a... musl: Upgrade to latest tip of trunk
    applied f37a9d3b5ec6... zip: Always enable LARGE_FILE_SUPPORT
    applied 66c96d1499d0... libmicrohttpd: Enable largefile support unconditionally
    applied 0e978df36d8c... unzip: Always enable largefile support
    applied ef5488d73260... default-distrovars: Remove largefile from defualt DISTRO_FEATURES
    applied 70700eab9cca... zlib: Resolve CVE-2022-37434
    applied ddb63d9e02b1... json-c: Fix function prototypes
    applied 6baf9b07a857... rsync: Backport fix to address CVE-2022-29154
    applied 61929f05d785... rsync: Upgrade to 3.2.5
    applied df6a394282c6... libtirpc: Backport fix for CVE-2021-46828
    applied bf0db7f88aaa... libxml2: Ignore CVE-2016-3709
    applied 96bd1c0f641d... tiff: Backport a patch for CVE-2022-34526
    applied 37b399f6ad32... libtirpc: Upgrade to 1.3.3
    applied dfc6a93d0bac... perf: Add packageconfig for libbfd support and use disabled as default
    applied 43bd04cf172b... packagegroup-self-hosted: update for strace
    applied b33cf2d113d0... connman: Backports for security fixes
    applied 1d6c7af0e358... package: Switch debug source handling to use prefix map
    applied 794371ad2da4... libgcc/gcc-runtime: Improve source reference handling
    applied 12bdb5df1ebb... bitbake.conf: Handle S and B separately for debug mapping
    applied a1190be53ad8... python3-cython: Update code to match debug path changes
    applied abbbc8712937... gcc-cross: Fix relative links
    applied abd30f85c649... gcc: Resolve relative prefix-map filenames
    applied 0e590ac76bb2... gcc: Add a patch to avoid hardcoded paths in libgcc on powerpc
    applied a01fd44f582a... gcc: Update patch status to submitted for two patches
    applied ad5936fba617... valgrind: Disable drd/tests/std_thread2 ptest
    applied 5edbe597fe0a... valgrind: Update to match debug file layout changes
    applied d63de87dd63b... skeleton/service: Ensure debug path handling works as intended
    applied 999b85baca11... msmtp: upgrade 1.8.20 -> 1.8.22
    applied 96e409c10f4a... systemd: Upgrade to 251.4 and fix build with binutils 2.39
    applied 500c7d307117... time: Add missing include for memset
    applied 84d16bfae3f3... screen: Add missing include files in configure checks
    applied a3e781582267... setserial: Fix build with clang
    applied 7dc5a703fb3c... expect: Fix implicit-function-declaration warnings
    applied b00f391a1ef7... shaderc: upgrade 2022.1 -> 2022.2
    applied 37c4ec602833... spirv-tools: Remove default copy constructor in header
    applied d34f6683ddb0... boost: Compile out stdlib unary/binary_functions for c++11 and newer
    applied f7e8bf37bcd6... vulkan-samples: Qualify move as std::move
    applied 59cc19b64d27... apt: Do not use std::binary_function
    applied 7e1091872464... ltp: Fix sys/mount.h and linux/mount.h conflict
    applied 5127df17c071... distrooverrides: Move back to classes whilst it's usage is clarified
    applied 79f85d85cafc... rpm: Remove -Wimplicit-function-declaration warnings
    applied 760cdeee7653... sysvinit-inittab/start_getty: Fix respawn too fast
    applied 44c867d7fbbc... glibc: apply proposed patch from upstream instead of revert
    applied c8570ddf2ef9... kernel-fitimage.bbclass: only package unique DTBs
    applied 75720e6af143... binutils: Upgrade to 2.39 release
    applied 76bd0f00fcab... binutils-cross: Disable gprofng for when building cross binutils
    applied e5af467dde34... binutils: Package up gprofng
    applied cf0cd9b21957... binutils: Disable gprofng when using clang
    applied d745c8b58846... binutils-cross-canadian: Package up new gprofng.rc file
    applied ca943bd72fb0... autoconf: Fix strict prototype errors in generated tests
    applied 51d8e0e20e29... rsync: Add missing prototypes to function declarations
    applied 7bde98700f8f... oeqa/parselogs: add qemuarmv5 arm-charlcd masking
    applied 0081575ff9b3... nfs-utils: Upgrade to 2.6.2
    applied d4b6ad56b707... grub2: fix several CVEs
    applied 25b3ebe17761... python3-cython: Remove debug lines
    applied 00b53aad1ea2... webkitgtk: Upgrade to 2.36.6 minor update
    applied 72aae2674a66... musl: Update to tip
    applied 7ab2366d1608... binutils: Disable gprofng on musl systems
    applied 426e265b4094... openssh: sync local ssh_config + sshd_config files with upstream 8.7p1
    applied 3e0d43b104e6... openssh: add support for config snippet includes to ssh and sshd
    applied 2bbf6c3fcf21... tzdata: upgrade 2022a -> 2022b
    applied 78d25f0800a3... libcgroup: update 2.0.2 -> 3.0.0
    applied c14857656207... python3-setuptools-rust: update 1.4.1 -> 1.5.1
    applied 222cf772685d... shadow: update 4.11.1 -> 4.12.1
    applied 7089bc24b448... slang: update 2.3.2 -> 2.3.3
    applied 304d1c917e61... xz: update 5.2.5 -> 5.2.6
    applied a5f2ae764a85... gdk-pixbuf: update 2.42.8 -> 2.42.9
    applied a5f8670fc4d1... xorgproto: update 2022.1 -> 2022.2
    applied 0c82598d22b6... boost-build-native: update 4.4.1 -> 1.80.0
    applied 07322357f7ce... boost: update 1.79.0 -> 1.80.0
    applied b933243afbaa... vulkan-samples: update to latest revision
    applied 8bdc7af5b679... epiphany: upgrade 42.3 -> 42.4
    applied 23afabfa5f8f... git: upgrade 2.37.1 -> 2.37.2
    applied 47e0b3f80d4b... glib-networking: upgrade 2.72.1 -> 2.72.2
    applied a2ac81ebf13f... gnu-efi: upgrade 3.0.14 -> 3.0.15
    applied fdf3e306635d... gpgme: upgrade 1.17.1 -> 1.18.0
    applied 71096622b095... libjpeg-turbo: upgrade 2.1.3 -> 2.1.4
    applied 02fd81ef9397... libwebp: upgrade 1.2.3 -> 1.2.4
    applied 56df3458ceaf... lighttpd: upgrade 1.4.65 -> 1.4.66
    applied a59bbc97bc6e... mesa: upgrade 22.1.5 -> 22.1.6
    applied 4dc8362117c4... meson: upgrade 0.63.0 -> 0.63.1
    applied c761ef2e5720... mpg123: upgrade 1.30.1 -> 1.30.2
    applied 4dca8ff9c934... pango: upgrade 1.50.8 -> 1.50.9
    applied b2a61cda1734... piglit: upgrade to latest revision
    applied f62e0a2ad4b2... pkgconf: upgrade 1.8.0 -> 1.9.2
    applied 759497be0135... python3-dtschema: upgrade 2022.8 -> 2022.8.1
    applied c55effa3045d... python3-more-itertools: upgrade 8.13.0 -> 8.14.0
    applied 6f3507305125... python3-numpy: upgrade 1.23.1 -> 1.23.2
    applied 4ab07d117d8c... python3-pbr: upgrade 5.9.0 -> 5.10.0
    applied 2938fff2d6ce... python3-pyelftools: upgrade 0.28 -> 0.29
    applied 4e5b0dbea8ec... python3-pytz: upgrade 2022.1 -> 2022.2.1
    applied aec2c0f364cb... strace: upgrade 5.18 -> 5.19
    applied 9aecc094ce81... sysklogd: upgrade 2.4.2 -> 2.4.4
    applied 5607db1ac669... wireless-regdb: upgrade 2022.06.06 -> 2022.08.12
    applied 19ef3a5dba4a... wpebackend-fdo: upgrade 1.12.0 -> 1.12.1
    applied bd4571c584aa... python3-hatchling: update 1.6.0 -> 1.8.0
    applied 5aca6cdb59e8... python3-setuptools: update 63.4.1 -> 65.0.2
    applied f2fb3c54a34c... devtool: do not leave behind source trees in workspace/sources
    applied 48124db7ca06... package_rpm: Do not replace square brackets in %files
    applied 077bf3c410bf... selftest: Add regression test for rpm filesnames
    applied d9c8d84f2b46... binutils: Upgrade to latest on 2.39 release branch
    applied 359ca09e7d52... sanity: add a comment to ensure CONNECTIVITY_CHECK_URIS is correct
    applied 081a3655fbb1... cargo_common.bbclass: Add missing space in shell conditional code
meta-security 2a2d650ee0 -> 571af37e9c:
    applied 8173cc90c881... python3-privacyidea: update to 3.7.3
    applied 13120455a55a... lkrg-module: update to 0.9.5
    applied a89102639293... apparmor: update to 3.0.6
    applied c352530c1374... packagegroup-core-security: add space for appends
    applied 8e26e9dc7aaa... cryptmount: Add new pkg
    applied 5f530ba5abad... packagegroup-core-security: add pkg to grp
    applied 571af37e9c93... meta-security: Add recipe for Glome
meta-arm 20a629180c -> 53870ee43e:
    applied 268f98c128c5... arm-bsp/secure-partitions: fix SMM gateway bug for EFI GetVariable()
    applied 44c58b3e553d... arm-bsp/u-boot: drop EFI GetVariable() workarounds patches
    applied 74a36b024f4d... docs: Update FVP_CONSOLES in runfvp documentation
    applied f83aad2ba9d4... docs: Introduce meta-arm OEQA documentation
    applied df1461b7d589... arm-bsp:corstone500: rebase u-boot patches on v2022.07
    applied dfe6d2f1ebb9... arm-bsp/corstone1000: rebase u-boot patches on top v2022.07
    applied 761712060275... arm-bsp/fvp-base-arm32: Update kernel patch for v5.19
    applied 2a92d6294d34... arm/qemuarm64-secureboot: remove tfa memory patch
    applied 769a09da7c65... arm/linux-yocto: remove optee num pages kernel config variable
    applied 038ca93bed26... arm-bsp/juno: drop scmi patch
    applied 257c69f11fb5... arm/qemuarm-secureboot: remove vmalloc from QB_KERNEL_CMDLINE_APPEND
    applied ee73c352ccb8... gator-daemon: Define _GNU_SOURCE feature test macro
    applied 74cab68b96a3... optee-os: Add section attribute parameters when clang is used
    applied 2327cb30337d... gem5/gem5-m5ops: Drop uneeded package inherit
    applied 98c515f42ee6... arm/fvp: use image-artifact-names as an image class
    applied 8058beeec1ae... atp/atp: drop package inherits
    applied ba502ba11e60... arm/optee: Update to 3.18
    applied 1badf7877fdc... arm-bsp/trusted-firmware-a: Bump TF-A version for N1SDP
    applied 5496260af77a... arm-bsp/optee: add optee-os support for N1SDP target
    applied f85bec2a1922... arm/optee: update optee-client to v3.18
    applied 53870ee43e57... arm-bsp/fvp-base: set preferred kernel to 5.15

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
