### PR TITLE
kirkstone: subtree update: cb2a94c39e -> 53fdac2b0a

### DIFF
--- a/kirkstone.conf
+++ b/kirkstone.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = kirkstone
-last_revision = a47ef046619d639dfbd3be2a13ef6d5b40fd40a1
+last_revision = acbe74879807fc6f82b62525d32c823899e19036
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,5 +20,5 @@ last_revision = c79262a30bd385f5dbb009ef8704a1a01644528e
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = kirkstone
-last_revision = e4b5c35fd430e1aec8218b4ae4ab51b2b919eec6
+last_revision = 387ab5f18b17c3af3e9e30dc58584641a70f359f
 


### PR DESCRIPTION
poky e4b5c35fd4 -> 387ab5f18b:
    applied 43ff43bd86c8... lua: Backport fix for CVE-2022-33099
    applied 7ac005ba752e... tiff: Security fixes CVE-2022-1354 and CVE-2022-1355
    applied 892bc9abc522... dpkg: fix CVE-2022-1664
    applied 9495687da9ed... bind: upgrade 9.18.2 -> 9.18.3
    applied 63aeff6e16b8... bind: upgrade 9.18.3 -> 9.18.4
    applied 4f2f86189582... gnupg: update 2.3.4 -> 2.3.6
    applied 1630dbb40bbf... gnupg: upgrade to 2.3.7 to fix CVE-2022-34903
    applied 6a0d24ba1c7d... vim: Upgrade 9.0.0021 -> 9.0.0063
    applied 2f95354b2b5c... go: update v1.17.10 -> v1.17.12
    applied db4ce356a84d... git: upgrade v2.35.3 -> v2.35.4
    applied ca3a1f17cc67... sstatesig: Include all dependencies in SPDX task signatures
    applied b581f1018942... rootfs-postcommands.bbclass: move host-user-contaminated.txt to ${S}
    applied ba0c2df27e77... gobject-introspection-data: Disable cache for g-ir-scanner
    applied 35b74ace9ce8... gcc: Backport a fix for gcc bug 105039
    applied 27fde9cc2aed... gcc-runtime: Pass -nostartfiles when building dummy libstdc++.so
    applied caae799d638b... qemu: CVE-2022-35414 can perform an uninitialized read on the translate_fail path, leading to an io_readx or io_writex crash
    applied d9fc65667834... libtirpc: CVE-2021-46828 DoS vulnerability with lots of connections
    applied 60c24eaf19b1... mkfontscale: upgrade 1.2.1 -> 1.2.2
    applied 398b1256fe05... xdpyinfo: upgrade 1.3.2 -> 1.3.3
    applied bd108838fafc... xorg-app: Tweak handling of compression changes in SRC_URI
    applied 407488a4c72d... xev: update 1.2.4 -> 1.2.5
    applied 4c0dae9d2278... xmodmap: update 1.0.10 -> 1.0.11
    applied f51f73db49f0... xf86-input-synaptics: update 1.9.1 -> 1.9.2
    applied d74f1d146438... encodings: update 1.0.5 -> 1.0.6
    applied 386218036901... font-util: update 1.3.2 -> 1.3.3
    applied 188a59b06ae3... xserver-xorg: update 21.1.3 -> 21.1.4
    applied f1e0068931eb... linux-firmware: update 20220610 -> 20220708
    applied e702d809e53c... libuv: upgrade 1.44.1 -> 1.44.2
    applied b1648bd505bd... log4cplus: upgrade 2.0.7 -> 2.0.8
    applied 40d98b7810a6... vala: upgrade 0.56.0 -> 0.56.1
    applied 12e12eeee07b... vala: upgrade 0.56.1 -> 0.56.2
    applied 8b3cb4287ca8... webkitgtk: upgrade 2.36.3 -> 2.36.4
    applied 820d82eccb36... xwayland: upgrade 22.1.1 -> 22.1.2
    applied eb2a6ff19e7f... xwayland: upgrade 22.1.2 -> 22.1.3
    applied 51acc9c217d7... epiphany: upgrade 42.2 -> 42.3
    applied 1e3f924eb7df... oeqa/runtime: add test that the kernel has CONFIG_PREEMPT_RT enabled
    applied f327cf107764... wic/plugins/rootfs: Fix NameError for 'orig_path'
    applied f16409bdfbd4... systemd: Added base_bindir into pkg_postinst:udev-hwdb.
    applied 307817321914... udev-extraconf:mount.sh: fix a umount issue
    applied ed19336407eb... perf: fix reproduciblity in older releases of Linux
    applied a78211a18231... base/reproducible: Change Source Date Epoch generation methods
    applied bef92ca0ce41... efivar: fix import functionality
    applied 948dc5120168... bind: Remove legacy python3 PACKAGECONFIG code
    applied 602922d49235... initscripts: run umountnfs as a KILL script
    applied 03e778a6361d... binutils: stable 2.38 branch updates
    applied f6bc8dfadb6c... package_manager/ipk: do not pipe stderr to stdout
    applied 33a1bfc66b12... libgcc: Fix standalone target builds with usrmerge distro feature
    applied 8fd330d520e9... linux-firwmare: restore WHENCE_CHKSUM variable
    applied 35f82bb72ec2... kernel.bbclass: pass LD also in savedefconfig
    applied 948f4dd1d33c... strace: set COMPATIBLE_HOST for riscv32
    applied ee75b4c5c984... openssh: Add openssh-sftp-server to openssh RDEPENDS
    applied 2b62807938b2... yocto-bsps: update to v5.10.113
    applied 5f1ede272093... yocto-bsps: update to v5.10.128 and buildpaths fixes
    applied 31de9a4fb70b... yocto-bsps: update to v5.15.52 and buildpaths fixes
    applied 169b7ab01735... yocto-bsps/5.10: fix buildpaths issue with gen-mach-types
    applied 1c171b786180... yocto-bsps/5.15: fix buildpaths issue with gen-mach-types
    applied a9427315d92e... yocto-bsps/5.10: fix buildpaths issue with pnmtologo
    applied cbc6cf9c5b14... yocto-bsps/5.15: fix buildpaths issue with pnmtologo
    applied 794cc6e16348... yocto-bsps: update to v5.15.54
    applied 7bd337569767... yocto-bsps: update to v5.10.130
    applied 38cbb4015d68... poky.conf: bump version for 4.0.3
    applied e96e1d8f99c2... glibc : stable 2.35 branch updates
    applied 20bcde8f6965... glibc: revert one upstream change to work around broken DEBUG_BUILD build
    applied 4a5dba835ae8... linux-yocto/5.10: update to v5.10.135
    applied fe74221b78ec... linux-yocto/5.15: update to v5.15.58
    applied ce80226252ca... linux-yocto-rt/5.15: update to -rt48 (and fix -stable merge)
    applied a8350d7a16ea... linux-yocto/5.15: update to v5.15.59
    applied 9031d7e8c193... linux-yocto/5.15: fix reproducibility issues
    applied 53916c4a6317... lttng-modules: update 2.13.3 -> 2.13.4
    applied 60171200800c... lttng-modules: Fix build failure for kernel v5.15.58
    applied 387ab5f18b17... build-appliance-image: Update to kirkstone head revision
meta-openembedded a47ef04661 -> acbe748798:
    applied cd54a3b37d31... libplist: ignore patched CVEs
    applied bd8f5fa080be... meta-oe: ignore patched CVEs
    applied aca019a2d0a6... mongodb: ignore unrelated CVEs
    applied b0bf2829a26e... php: ignore patched CVEs
    applied 4f0231595fb5... postgresql: ignore unrelated CVE
    applied f1d7666dceff... catfish: fix buildpaths issue
    applied db866d51f8c1... rsyslog: update 8.2202->8.2206
    applied 7eb9e5004af3... php: upgrade 8.1.7 -> 8.1.8
    applied 44d773044f0b... ndisc6: upgrade 1.0.5 -> 1.0.6
    applied 7430daa22dda... bigbuckbunny-1080p: update SRC_URI
    applied 2763eaf35f9b... openjpeg: ignore CVE-2015-1239
    applied cb4e7fb4b08b... python3-lxml: Security fix CVE-2022-2309
    applied b9c0df23f961... stunnel: upgrade 5.63 -> 5.64
    applied ab72f6b1aef6... stunnel: upgrade 5.64 -> 5.65
    applied d3e5c086bcb6... redis: upgrade 7.0.2 -> 7.0.4
    applied 6f3b39ffb6b1... tracker: upgrade 3.3.0 -> 3.3.1
    applied 8f2dc1023482... tracker: upgrade 3.3.1 -> 3.3.2
    applied a8b879b58a37... glmark2: fix compatibility with python-3.11
    applied 64f95345ad38... polkit: add udisks2 rule
    applied 5b7f7f31ffd3... polkit-group-rule-udisks2: fix override syntax in RDEPENDS
    applied eb9a5dcbf3b9... polkit: Add --shell /bin/nologin to polkitd user
    applied 3207be50c5b5... polkit: update patches for musl compilation
    applied 72d3abde62f2... ibus: Swith to use main branch instead of master
    applied 2594e977785f... net-snmp: set ac_cv_path_PSPROG
    applied fe7250a32182... postgresql: Fix the buildpaths issue
    applied 055f26ce9a26... freeradius: Fix buildpaths issue
    applied bbfdaf4cb6a2... openipmi: Fix buildpaths issue
    applied 78e65e779922... apache2: Fix the buildpaths issue
    applied 73a17ff992d2... frr: fix buildpaths issue
    applied 9165fb0d1fde... yasm: fix buildpaths warning
    applied ce74ad4b5167... libwebsockets: Avoid absolute paths in *.cmake files in the sysroot
    applied acbe74879807... cryptsetup: Add support for building without SSH tokens

openbmc-subtree update -c kirkstone.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
