### PR TITLE
dunfell: subtree update: ab475af389 -> cddccf4ad5

### DIFF
--- a/dunfell.conf
+++ b/dunfell.conf
@@ -92,7 +92,7 @@ last_revision = 168440a0f1c89fc8ef6cabea033c5611d323df89
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = dunfell
-last_revision = fdd1dfe6b4b2412cc536c26450ce126c960d8107
+last_revision = f22bf6efaae61a8fd9272be64e7d75223c58922e
 
 [meta-openpower]
 src_uri = https://gerrit.openbmc-project.xyz/openbmc/meta-openpower
@@ -128,7 +128,7 @@ last_revision = 2a53c3569af7fa1b0e1736d179e8178ffecf427d
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = dunfell
-last_revision = 934064a01903b2ba9a82be93b3f0efdb4543a0e8
+last_revision = 2081e1bb9a44025db7297bfd5d024977d42191ed
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -158,5 +158,5 @@ last_revision = 7eef85ee0d2e6f8100c06c0f9a9cb52c941ecd50
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = dunfell
-last_revision = b6ce93d565cec4eca94da05f3b9bf7f6bf115b75
+last_revision = 4aad5914efe9789755789856882aac53de6c4ed3
 


### PR DESCRIPTION
poky b6ce93d565 -> 4aad5914ef:
    applied 08a3ac8403fa... vim: Upgrade 8.2.4524 -> 8.2.4681
    applied 170ce893e750... gzip: fix CVE-2022-1271
    applied f36e87ec4f6e... zlib: backport the fix for CVE-2018-25032
    applied 62aefd3864e2... xz: fix CVE-2022-1271
    applied 507183f4b082... git: Ignore CVE-2022-24975
    applied 112973ae371c... pseudo: Add patch to workaround paths with crazy lengths
    applied ba9b4222e16d... pseudo: Fix handling of absolute links
    applied aee507fe6c5e... license_image.bbclass: close package.manifest file
    applied 39ba556a2e44... apt: add -fno-strict-aliasing to CXXFLAGS to fix SHA256 bug
    applied 076d50da2e56... metadata_scm.bbclass: Use immediate expansion for the METADATA_* variables
    applied 1a14b4f69354... libxshmfence: Correct LICENSE to HPND
    applied 0ab1adc2fcdf... documentation: update for 3.1.16 release
    applied ef1323fbb7c8... poky.conf: Bump version for 3.1.16 release
    applied 57e1d6d9a686... linux-firmware: upgrade 20220310 -> 20220411
    applied f62b02845235... wireless-regdb: upgrade 2022.02.18 -> 2022.04.08
    applied 8fdcbd703bbd... u-boot: Correct the SRC_URI
    applied b82a9877d5d9... git update from 2.24.3 to 2.24.4
    applied a14b11c500d8... linux-yocto/5.4: update to v5.4.182
    applied 31766c908e0b... linux-yocto/5.4: update to v5.4.183
    applied 41cd7b5e3b35... linux-yocto/5.4: update to v5.4.186
    applied 65d3f419d4ed... linux-yocto/5.4: update to v5.4.188
    applied 8a7fd5f633a2... linux-yocto/5.4: update to v5.4.190
    applied f14992950eb9... build-appliance-image: Update to dunfell head revision
    applied 86cdd92b1510... tiff: Fix CVE-2022-0891
    applied 49032f1e8d04... boost: don't specify gcc version
    applied 5b0093ecee4b... linux-firmware: correct license for ar3k firmware
    applied dcd40cfa375c... cve-check: add json format
    applied 319ca9f46093... perf-build-test/report: Drop phantomjs and html email reports support
    applied 64f632c93f48... scripts/contrib/oe-build-perf-report-email.py: remove obsolete check for phantomjs and optipng
    applied 4dfdb53c8ac5... python3: ignore CVE-2015-20107
    applied b4ba37ce13e8... busybox: Use base_bindir instead of hardcoding /bin path
    applied e47d35353c12... cases/buildepoxy.py: fix typo
    applied 90cf135b046e... install/devshell: Introduce git intercept script due to fakeroot issues
    applied 3a9cef8dbe3b... base: Drop git intercept
    applied eba0e64a88af... neard: Switch SRC_URI to git repo
    applied a03e13a00b7c... uninative: Upgrade to 3.6 with gcc 12 support
    applied de244668232f... fribidi: Add fix for CVE-2022-25308, CVE-2022-25309 and CVE-2022-25310
    applied 5daf9735c909... libinput: Add fix for CVE-2022-1215
    applied d68406497e71... busybox: fix CVE-2022-28391
    applied 24f305b4dda7... linux-yocto/5.4: update to v5.4.192
    applied 66b0097533eb... cve-check: no need to depend on the fetch task
    applied dd76704ea5e0... cve-update-db-native: update the CVE database once a day only
    applied 2120a39b09e3... cve-update-db-native: let the user to drive the update interval
    applied 46e00399e5ce... cve-check: add JSON format to summary output
    applied 49cd9f898f6c... cve-check: fix symlinks where link and output path are equal
    applied c408846f4189... volatile-binds: Change DefaultDependencies from false to no
    applied 6327db048b78... rootfs-postcommands: fix symlinks where link and output path are equal
    applied 31970fb2a4e1... base: Avoid circular references to our own scripts
    applied a75678145b35... scripts: Make git intercept global
    applied a48231b5bfb5... scripts/git: Ensure we don't have circular references
    applied 61c36064c8c3... vim: Upgrade 8.2.4681 -> 8.2.4912
    applied fec7f76cfcf9... curl: Fix CVEs for curl
    applied 37bbb105c932... tiff: Add patches to fix multiple CVEs
    applied 5999f70889d4... freetype: Fix CVEs for freetype
    applied dfd14979615e... git: Use CVE_CHECK_WHITELIST instead of CVE_CHECK_IGNORE
    applied 5c616134052a... openssl: Minor security upgrade 1.1.1n to 1.1.1o
    applied 72385662c802... linux-firmware: replace mkdir by install
    applied afc8929c5b31... linux-firmware: upgrade 20220411 -> 20220509
    applied e8255f508664... selftest: skip virgl test on alma 8.6
    applied b4e5bf3e7f6b... manuals: add missing space in appends
    applied 232b5533de22... cve-check: Fix report generation
    applied 475b0d3fad96... pcre2: CVE-2022-1586 Out-of-bounds read
    applied 0f83e5bd4267... mobile-broadband-provider-info: upgrade 20220315 -> 20220511
    applied 0ca0aec7aa3a... oeqa/selftest/cve_check: add tests for recipe and image reports
    applied df1129b02264... ruby: Upgrade ruby to 2.7.6 for security fix
    applied d6941efc0bab... ruby: Whitelist CVE-2021-28966 as this affects Windows OS only
    applied f0d18846de3b... libsdl2: Add fix for CVE-2021-33657
    applied 38b588a1a12f... ffmpeg: Fix for CVE-2022-1475
    applied 396373610c75... ncurses: Fix CVE-2022-29458
    applied c2bd2eae86df... libxml2: Fix CVE-2022-29824 for libxml2
    applied 34aaa93bfe26... vim: Upgrade 8.2.4912 -> 8.2.5034 to fix 9 CVEs
    applied 08fb6eb2e09b... cve-check.bbclass: Added do_populate_sdk[recrdeptask].
    applied b0cff6d434a2... cve-check: Add helper for symlink handling
    applied cc3cefdb43da... cve-check: Only include installed packages for rootfs manifest
    applied 898aedf58544... cve-check: Allow warnings to be disabled
    applied 86146334f1b8... documentation: update for 3.1.17 release
    applied bb6c7e09e35b... poky.conf: bump version for 3.1.17 release
    applied 1e298a42223d... openssl: Backport fix for ptest cert expiry
    applied 27877797c7bd... Revert "openssl: Backport fix for ptest cert expiry"
    applied 196895a482ea... openssl: backport fix for ptest certificate expiration
    applied 99478d73c5d2... openssl: update the epoch time for ct_test ptest
    applied 77332ffb9bdc... e2fsprogs: CVE-2022-1304 out-of-bounds read/write via crafted filesystem
    applied 6be9d793a33a... pcre2: CVE-2022-1587 Out-of-bounds read
    applied d3d92d7852e8... libxslt: Fix CVE-2021-30560
    applied 1be2437fd2a8... libxslt: Mark CVE-2022-29824 as not applying
    applied 7da79fcac2eb... curl: Backport CVE fixes
    applied 42bb9689a0a1... curl: Fix CVE_CHECK_WHITELIST typo
    applied 6cf824520a23... cve-check: move update_symlinks to a library
    applied f2d12bc50bc7... cve-check: write empty fragment files in the text mode
    applied 9868f9914901... cve-check: add coverage statistics on recipes with/without CVEs
    applied e87384031782... cve-update-db-native: make it possible to disable database updates
    applied 7f694e46a87a... linux-yocto/5.4: update to v5.4.196
    applied 238fb8943421... local.conf.sample: Update sstate url to new 'all' path
    applied 95cda9d09165... cups: fix CVE-2022-26691
    applied 23ed0037b698... openssh: Whitelist CVE-2021-36368
    applied 8d6f9680e45d... vim: Upgrade 8.2.5034 -> 8.2.5083
    applied 8a382d865534... kernel-yocto.bbclass: Reset to exiting on non-zero return code at end of task
    applied 1487d6838891... alsa-plugins: fix libavtp vs. avtp packageconfig
    applied f51a25441545... license.bbclass: Bound beginline and endline in copy_license_files()
    applied 9638dc4826ec... rootfs.py: close kernel_abi_ver_file
    applied 69fb63b4fc5d... archiver: use bb.note instead of echo
    applied 7d9d97368b66... oescripts: change compare logic in OEListPackageconfigTests
    applied a2805141e99d... e2fsprogs: add alternatives handling of lsattr as well
    applied d4c7b40039c7... gcc-source: Fix incorrect task dependencies from ${B}
    applied 5582ab6aae49... archiver: don't use machine variables in shared recipes
    applied 2ae3d4362871... python-pip: CVE-2021-3572 Incorrect handling of unicode separators in git references
    applied fe6c34c48db8... golang: CVE-2021-44717 syscall: don't close fd 0 on ForkExec error
    applied ae90fa778a41... dpkg: update to 1.19.8
    applied 0b84202a2b6d... systemd: systemd-systemctl: Support instance conf files during enable
    applied b9bffd765017... linux-firmware: add support for building snapshots
    applied 872caf23addf... linux-firmware: upgrade 20220509 -> 20220610
    applied 6d1f8412becc... bitbake: tinfoil/data_smart: Allow variable history emit() to function remotely
    applied 9f20f682ffd2... bitbake: bin/bitbake-getvar: Add a new command to query a variable value (with history)
    applied 07eca06c715d... bitbake: knotty: display active tasks when printing keepAlive() message
    applied 33a08f7b8f05... bitbake: knotty: reduce keep-alive timeout from 5000s (83 minutes) to 10 minutes
    applied 02867c90395d... manuals: switch to the sstate mirror shared between all versions
    applied 3f2da49c2b6c... golang: CVE-2022-24675 encoding/pem: fix stack overflow in Decode
    applied 6013fc2606d7... golang: CVE-2021-31525 net/http: panic in ReadRequest and ReadResponse when reading a very large header
    applied 4bc2324a2528... unzip: fix CVE-2021-4217
    applied 31b4392e6e95... unzip: Port debian fixes for two CVEs
    applied 6e79d96c6ded... cve-check: add support for Ignored CVEs
    applied b6f4778e379a... grub2: CVE-2021-3981 Incorrect permission in grub.cfg allow unprivileged user to read the file content
    applied 79b3e05767fd... oeqa/selftest/cve_check: add tests for Ignored and partial reports
    applied 0a0e0663abad... wireless-regdb: upgrade 2022.04.08 -> 2022.06.06
    applied d2f8a57a3006... lttng-modules: Backport Linux 5.18+, 5.15.44+, 5.10.119+ fixes
    applied 8dfc7162e317... initramfs-framework: move storage mounts to actual rootfs
    applied 684c5d4c1281... wic: fix WicError message
    applied 159a2de14680... insane.bbclass: host-user-contaminated: Correct per package home path
    applied ca90350d1370... cve-extra-exclusions: Clean up and ignore three CVEs (2xqemu and nasm)
    applied 1c38d0d3d66f... cve-check: hook cleanup to the BuildCompleted event, not CookerExit
    applied 6a3d60d87328... openssl: Minor security upgrade 1.1.1o to 1.1.1p
    applied 60a98feb86dd... vim: 8.2.5083 -> 9.0.0005
    applied 232fdbf0e5fe... linux-yocto/5.4: update to v5.4.199
    applied 387d23c02ea0... linux-yocto/5.4: update to v5.4.203
    applied 3860414240c3... efivar: change branch name to main
    applied 79ac8cf1614b... oeqa/runtime/scp: Disable scp test for dropbear
    applied a985415ec20e... packagegroup-core-ssh-dropbear: Add openssh-sftp-server recommendation
    applied 43980058ca01... oe-selftest-image: Ensure the image has sftp as well as dropbear
    applied 010094a2ae3c... openssh: break dependency on base package for -dev package
    applied 48ea7812c783... dropbear: break dependency on base package for -dev package
    applied 35bcc2898320... IMAGE_LOCALES_ARCHIVE: add option to prevent locale archive creation
    applied eb12590623f9... qemu: add PACKAGECONFIG for capstone
    applied 9c5b33ccbabf... bitbake: fetch/git: Fix usehead for non-default names
    applied 50aa474c841c... bitbake: fetch/wget: Move files into place atomically
    applied 7350f515b328... openssl: security upgrade 1.1.1p to 1.1.1q
    applied 61023f9e61d6... vim: upgrade to 9.0.0021
    applied dee08141f250... classes/cve-check: Move get_patches_cves to library
    applied b38628041bc1... documentation: update for 3.1.18 release
    applied 61ea9f7665d5... ref-manual: Add XZ_THREADS and XZ_MEMLIMIT
    applied 17c23e485e47... ref-manual: variables: remove sphinx directive from literal block
    applied 868ebed326f9... cve-extra-exclusions.inc: Use CVE_CHECK_WHITELIST
    applied 24fc40faefc6... curl: Fix CVE-2022-32206, CVE-2022-32207, and CVE-2022-32208
    applied 88be415b10f7... linux-yocto/5.4: update to v5.4.205
    applied eb32f7f5e6f3... linux-yocto-rt/5.4: fixup -rt build breakage
    applied 08bd8cc1148b... poky.conf: bump version for 3.1.18 release
    applied d695bd0d3dc6... build-appliance-image: Update to dunfell head revision
    applied d32392304723... gnupg: CVE-2022-34903 possible signature forgery via injection into the status line
    applied 97810ff2d785... libjpeg-turbo: Fix CVE-2021-46822
    applied e4946bd39eed... kernel-fitimage.bbclass: add padding algorithm property in config nodes
    applied 9e7f4a7db257... grub2: Fix buffer underflow write in the heap
    applied 25606f450dc9... qemu: CVE-2022-35414 can perform an uninitialized read on the translate_fail path, leading to an io_readx or io_writex crash
    applied 038831674e25... libTiff: CVE-2022-2056 CVE-2022-2057 CVE-2022-2058 DoS from Divide By Zero Error
    applied b9ae8da74e25... libtirpc: CVE-2021-46828 DoS vulnerability with lots of connections
    applied 820e8891b8b6... grub2: Fix several security issue of integer underflow
    applied c35c1e15f0e9... gdk-pixbuf: CVE-2021-46829 a heap-based buffer overflow
    applied c4499b85f70b... cve_check: skip remote patches that haven't been fetched when searching for CVE tags
    applied b365d212dc03... linux-yocto/5.4: update to v5.4.208
    applied 883102b9b8bc... linux-yocto/5.4: update to v5.4.209
    applied 354f571f6145... insane: Fix buildpaths test to work with special devices
    applied 7c7fc0de7191... libmodule-build-perl: Use env utility to find perl interpreter
    applied 0c3dfb682d3c... openssh: Add openssh-sftp-server to openssh RDEPENDS
    applied b361f2a931bc... selftest: skip virgl test on fedora 36
    applied 54846f581e6a... libxml2: Port gentest.py to Python-3
    applied 5b956ef359ae... gstreamer1.0: use the correct meson option for the capabilities
    applied cfd2eaa0e196... qemu: CVE-2020-27821 heap buffer overflow in msix_table_mmio_write
    applied ae4acc9f81e8... gnutls: CVE-2022-2509 Double free during gnutls_pkcs7_verify
    applied 98dd6e4cac39... zlib: CVE-2022-37434 a heap-based buffer over-read
    applied 5373e681cf22... vim: Upgrade 9.0.0021 -> 9.0.0063
    applied ef2da8f28e54... vim: update from 9.0.0063 to 9.0.0115
    applied 0b85e5d61073... linux-firmware: update 20220610 -> 20220708
    applied 2340b1dbb998... linux-firwmare: restore WHENCE_CHKSUM variable
    applied 59180eb47419... kernel-arch: Fix buildpaths leaking into external module compiles
    applied f97bd9abe6fb... bin_package: install into base_prefix
    applied 9243169d4f5b... rootfs-postcommands.bbclass: move host-user-contaminated.txt to ${S}
    applied 1fc880e1658d... initscripts: run umountnfs as a KILL script
    applied fc24cd194812... bitbake: fetch2/wget: Update user-agent
    applied 139225f0ba8e... documentation: update for 3.1.19 release
    applied 23322786e024... poky.conf: bump version for 3.1.19 release
    applied 4aad5914efe9... build-appliance-image: Update to dunfell head revision
meta-raspberrypi 934064a019 -> 2081e1bb9a:
    applied 2081e1bb9a44... linux-firmware-rpidistro: fix wifi driver loading on cm4
meta-openembedded fdd1dfe6b4 -> f22bf6efaa:
    applied 8ff12bfffcf0... postgresql: Fix build on riscv
    applied a8d82c80a11b... atftp: Add fix for CVE-2021-41054 and CVE-2021-46671
    applied abd7cf838d51... lua: fix CVE-2022-28805
    applied b99a386cd139... python3-cryptography: backport 3 changes to fix CVE-2020-36242
    applied de4b76934c20... ostree: prevent ostree-native depending on target virtual/kernel to provide kernel-module-overlay
    applied a38c92d8e9a2... openjpeg: Whitelist CVE-2020-27844 and CVE-2015-1239
    applied c9e034fbaad4... opencl-icd-loader: switch to main branch
    applied a1c7bb209870... fuse: set CVE_PRODUCT to "fuse_project:fuse"
    applied 9f361cff9c73... opencl-headers: switch to main branch
    applied deee22601787... tcpdump: Add fix for CVE-2018-16301
    applied 04212afa12e4... mariadb: update to 10.4.25
    applied 986bb14aafe5... python3-matplotlib: add missing dependency
    applied 2526b14d3914... tesseract-lang: switch from master branch to main
    applied d865d97f9bcf... bridge-utils: Switch to use the main branch
    applied 96e9636f7dea... leveldb: switch from master branch to main
    applied 245a1ab46bd2... grpc: switch from master branch to main for upb
    applied 512a3caee4a5... iperf: Set CVE_PRODUCT to "iperf_project:iperf"
    applied d6795ab0eed5... php: move to version v7.4.28
    applied 1d0b2d78c262... ntfs-3g-ntfsprogs: Set CVE_PRODUCT to "tuxera:ntfs-3g"
    applied a24773d39edf... openldap: CVE-2022-29155 OpenLDAP SQL injection
    applied b406297d3bcd... xterm: CVE-2022-24130 Buffer overflow in set_sixel in graphics_sixel.c
    applied 9f3d116fddd8... cyrus-sasl: CVE-2022-24407 failure to properly escape SQL input allows an attacker to execute arbitrary SQL commands
    applied 52cee67833d1... ntfs-3g-ntfsprogs: upgrade to 2021.8.22
    applied 3ba409127c2f... ntfs-3g-ntfsprogs: upgrade to 2022.5.17
    applied a04c5444c901... bigbuckbunny-1080p: update SRC_URI
    applied f22bf6efaae6... meta-oe: Add leading whitespace for append operator

openbmc-subtree update -c dunfell.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
